### PR TITLE
style: Checkstyle 규칙 강화 - 중괄호 필수

### DIFF
--- a/config/checkstyle/google_checks.xml
+++ b/config/checkstyle/google_checks.xml
@@ -67,13 +67,11 @@
       <property name="tokens"
                 value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
     </module>
-    <!-- NeedBraces: 단일 문장 if/for/while에서 중괄호 필수 검사 완화 -->
-    <!--
+    <!-- NeedBraces: 단일 문장 if/for/while에서 중괄호 필수 (프로젝트 규칙) -->
     <module name="NeedBraces">
       <property name="tokens"
                 value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
     </module>
-    -->
     <module name="LeftCurly">
       <property name="tokens"
                 value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
@@ -356,9 +354,10 @@
     </module>
     -->
     <!-- MissingJavadocType: 클래스/인터페이스 Javadoc 필수 검사 완화 -->
+    <!-- Clean Code 철학: 좋은 코드는 주석 없이도 이해할 수 있어야 함 -->
     <!--
     <module name="MissingJavadocType">
-      <property name="scope" value="protected"/>
+      <property name="scope" value="public"/>
       <property name="tokens"
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
                       RECORD_DEF, ANNOTATION_DEF"/>


### PR DESCRIPTION
- NeedBraces 규칙 활성화: if/for/while/do/else에서 중괄호 필수
- Javadoc 규칙은 완화 유지: Clean Code 철학에 따라 코드 자체가 자명해야 함
- 프로젝트 코드 스타일 규칙 (.editorconfig)과 일치
- 모든 테스트 통과 및 빌드 성공 확인

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Checkstyle NeedBraces for all control statements and updates Javadoc-related comments while keeping Javadoc checks disabled.
> 
> - **Checkstyle config (`config/checkstyle/google_checks.xml`)**:
>   - **Enforce `NeedBraces`**: enable braces requirement for `LITERAL_DO`, `LITERAL_ELSE`, `LITERAL_FOR`, `LITERAL_IF`, `LITERAL_WHILE`.
>   - **Javadoc rules**: keep `MissingJavadocType` disabled; add note on Clean Code and adjust example `scope` to `public` within the commented block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e1a54cce913d2775f848c65bbe236f4fadac55f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->