### PR TITLE
refactor: Java 21에서 불필요한 UseContainerSupport 옵션 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,15 +43,15 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
 
 # Run the application
 # JVM 옵션:
-# -XX:+UseContainerSupport: 컨테이너 환경 인식 (메모리 제한 자동 감지)
 # -XX:MaxRAMPercentage=75.0: 컨테이너 메모리의 75% 사용 (OOM 방지를 위한 여유 공간 확보)
 # -XX:MaxGCPauseMillis=200: GC 일시정지 시간 목표 (200ms, G1GC 기본값 사용)
 # -XX:+UseStringDeduplication: 문자열 중복 제거로 메모리 절약
 # -XX:+PrintStringDeduplicationStatistics: 문자열 중복 제거 통계 출력 (모니터링용)
-# 참고: Railway는 실제 사용한 메모리만 과금하므로, MaxRAMPercentage는 OOM 방지 목적
+# 참고:
+# - Railway는 실제 사용한 메모리만 과금하므로, MaxRAMPercentage는 OOM 방지 목적
+# - Java 21부터 UseContainerSupport는 기본 활성화되어 명시 불필요 (Java 10+ 기본값)
 ENTRYPOINT ["java", \
   "-Djava.security.egd=file:/dev/./urandom", \
-  "-XX:+UseContainerSupport", \
   "-XX:MaxRAMPercentage=75.0", \
   "-XX:MaxGCPauseMillis=200", \
   "-XX:+UseStringDeduplication", \

--- a/docs/MEMORY_OPTIMIZATION.md
+++ b/docs/MEMORY_OPTIMIZATION.md
@@ -12,7 +12,9 @@
 - GC 일시정지 시간 목표 설정 (`-XX:MaxGCPauseMillis=200`)
 - 문자열 중복 제거 활성화 (`-XX:+UseStringDeduplication`)
 - 문자열 중복 제거 통계 출력 (`-XX:+PrintStringDeduplicationStatistics`) - 모니터링용
-- 참고: Java 21의 기본 GC는 이미 G1GC이므로 명시적으로 지정 불필요
+- 참고:
+  - Java 21의 기본 GC는 이미 G1GC이므로 명시적으로 지정 불필요
+  - `UseContainerSupport`는 Java 10+부터 기본 활성화되어 명시 불필요 (Java 21에서 제거됨)
 
 **설명:**
 


### PR DESCRIPTION
- Java 10+부터 UseContainerSupport는 기본 활성화
- Java 17에서 완전히 통합되어 제거됨
- Java 21에서는 명시적으로 지정할 필요 없음