### PR TITLE
chore(deps) AutoConfigure Flyway

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     // Database
     runtimeOnly(libs.mysql.connector.j)
+    implementation(libs.flyway.mysql)
 
     // SQL Logging (DataSource Proxy)
     implementation(libs.p6spy.spring.boot.starter)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-st
 
 # Database
 mysql-connector-j = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-connector" }
+flyway-mysql = { module = "org.flywaydb:flyway-mysql" }
 
 # SQL Logging
 p6spy-spring-boot-starter = { module = "com.github.gavlyukovskiy:p6spy-spring-boot-starter", version.ref = "p6spy" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches to Spring Boot Flyway starter and uses `flyway-mysql`, simplifying Flyway dependency management.
> 
> - **Build/Dependencies**:
>   - Replace Flyway bundle with `spring-boot-starter-flyway` in `gradle/libs.versions.toml` and include it in `bundles.spring-boot-starters`.
>   - Switch Gradle dependency from `libs.bundles.flyway` to `libs.flyway.mysql` in `build.gradle.kts`.
>   - Remove explicit Flyway version and `flyway-core`; keep `flyway-mysql` without version ref.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef2ceca476bab953164bce3e227c019a8531d26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->