### PR TITLE
refactor: Invitation.status / FamilyMember.role Enum 전환

### DIFF
--- a/src/main/java/com/bifos/accountbook/application/dto/invitation/InvitationResponse.java
+++ b/src/main/java/com/bifos/accountbook/application/dto/invitation/InvitationResponse.java
@@ -1,6 +1,7 @@
 package com.bifos.accountbook.application.dto.invitation;
 
 import com.bifos.accountbook.domain.entity.Invitation;
+import com.bifos.accountbook.domain.value.InvitationStatus;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +18,7 @@ public class InvitationResponse {
   private String familyUuid;
   private String familyName;
   private String token;
-  private String status;
+  private InvitationStatus status;
   private LocalDateTime expiresAt;
   private LocalDateTime createdAt;
   private boolean isExpired;
@@ -25,7 +26,7 @@ public class InvitationResponse {
 
   public static InvitationResponse from(Invitation invitation) {
     boolean isExpired = invitation.getExpiresAt().isBefore(LocalDateTime.now());
-    boolean isUsed = "ACCEPTED".equals(invitation.getStatus());
+    boolean isUsed = InvitationStatus.ACCEPTED == invitation.getStatus();
 
     return InvitationResponse.builder()
                              .uuid(invitation.getUuid().getValue())

--- a/src/main/java/com/bifos/accountbook/application/service/FamilyService.java
+++ b/src/main/java/com/bifos/accountbook/application/service/FamilyService.java
@@ -13,6 +13,7 @@ import com.bifos.accountbook.domain.repository.ExpenseRepository;
 import com.bifos.accountbook.domain.repository.FamilyMemberRepository;
 import com.bifos.accountbook.domain.repository.FamilyRepository;
 import com.bifos.accountbook.domain.value.CustomUuid;
+import com.bifos.accountbook.domain.value.FamilyMemberRole;
 import com.bifos.accountbook.presentation.annotation.FamilyUuid;
 import com.bifos.accountbook.presentation.annotation.UserUuid;
 import com.bifos.accountbook.presentation.annotation.ValidateFamilyAccess;
@@ -60,7 +61,7 @@ public class FamilyService {
     FamilyMember member = FamilyMember.builder()
                                       .familyUuid(family.getUuid())
                                       .userUuid(user.getUuid())
-                                      .role("owner")
+                                      .role(FamilyMemberRole.OWNER)
                                       .build();
 
     familyMemberRepository.save(member);

--- a/src/main/java/com/bifos/accountbook/application/service/FamilyValidationService.java
+++ b/src/main/java/com/bifos/accountbook/application/service/FamilyValidationService.java
@@ -7,6 +7,7 @@ import com.bifos.accountbook.domain.entity.FamilyMember;
 import com.bifos.accountbook.domain.repository.FamilyMemberRepository;
 import com.bifos.accountbook.domain.repository.FamilyRepository;
 import com.bifos.accountbook.domain.value.CustomUuid;
+import com.bifos.accountbook.domain.value.FamilyMemberRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -59,11 +60,11 @@ public class FamilyValidationService {
                                                         .addParameter("userUuid", userUuid.getValue())
                                                         .addParameter("familyUuid", familyUuid.getValue()));
 
-    if (!"owner".equals(membership.getRole())) {
+    if (membership.getRole() != FamilyMemberRole.OWNER) {
       throw new BusinessException(ErrorCode.FORBIDDEN, "가족 소유자만 이 작업을 수행할 수 있습니다")
           .addParameter("userUuid", userUuid.getValue())
           .addParameter("familyUuid", familyUuid.getValue())
-          .addParameter("role", membership.getRole());
+          .addParameter("role", membership.getRole().getCode());
     }
   }
 

--- a/src/main/java/com/bifos/accountbook/application/service/InvitationService.java
+++ b/src/main/java/com/bifos/accountbook/application/service/InvitationService.java
@@ -12,6 +12,7 @@ import com.bifos.accountbook.domain.repository.FamilyMemberRepository;
 import com.bifos.accountbook.domain.repository.FamilyRepository;
 import com.bifos.accountbook.domain.repository.InvitationRepository;
 import com.bifos.accountbook.domain.value.CustomUuid;
+import com.bifos.accountbook.domain.value.FamilyMemberRole;
 import com.bifos.accountbook.presentation.annotation.FamilyUuid;
 import com.bifos.accountbook.presentation.annotation.UserUuid;
 import com.bifos.accountbook.presentation.annotation.ValidateFamilyAccess;
@@ -129,7 +130,7 @@ public class InvitationService {
     FamilyMember member = FamilyMember.builder()
                                       .familyUuid(invitation.getFamilyUuid())
                                       .userUuid(user.getUuid())
-                                      .role("member")
+                                      .role(FamilyMemberRole.MEMBER)
                                       .build();
 
     familyMemberRepository.save(member);
@@ -183,11 +184,11 @@ public class InvitationService {
                                                         .addParameter("userUuid", userUuid.getValue())
                                                         .addParameter("familyUuid", invitation.getFamilyUuid().getValue()));
 
-    if (!"owner".equals(membership.getRole())) {
+    if (membership.getRole() != FamilyMemberRole.OWNER) {
       throw new BusinessException(ErrorCode.FORBIDDEN, "초대장을 삭제할 권한이 없습니다")
           .addParameter("userUuid", userUuid.getValue())
           .addParameter("familyUuid", invitation.getFamilyUuid().getValue())
-          .addParameter("role", membership.getRole());
+          .addParameter("role", membership.getRole().getCode());
     }
   }
 }

--- a/src/main/java/com/bifos/accountbook/domain/entity/FamilyMember.java
+++ b/src/main/java/com/bifos/accountbook/domain/entity/FamilyMember.java
@@ -1,6 +1,7 @@
 package com.bifos.accountbook.domain.entity;
 
 import com.bifos.accountbook.domain.value.CustomUuid;
+import com.bifos.accountbook.domain.value.FamilyMemberRole;
 import com.bifos.accountbook.domain.value.FamilyMemberStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,7 +47,7 @@ public class FamilyMember {
 
   @Column(nullable = false, length = 20)
   @Builder.Default
-  private String role = "member";
+  private FamilyMemberRole role = FamilyMemberRole.MEMBER;
 
   @Column(name = "joined_at", nullable = false)
   @Builder.Default

--- a/src/main/java/com/bifos/accountbook/domain/entity/Invitation.java
+++ b/src/main/java/com/bifos/accountbook/domain/entity/Invitation.java
@@ -1,6 +1,7 @@
 package com.bifos.accountbook.domain.entity;
 
 import com.bifos.accountbook.domain.value.CustomUuid;
+import com.bifos.accountbook.domain.value.InvitationStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -54,7 +55,7 @@ public class Invitation {
 
   @Column(nullable = false, length = 50)
   @Builder.Default
-  private String status = "PENDING";
+  private InvitationStatus status = InvitationStatus.PENDING;
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
@@ -82,13 +83,13 @@ public class Invitation {
    * 초대 수락
    */
   public void accept() {
-    if (!"PENDING".equals(this.status)) {
+    if (this.status != InvitationStatus.PENDING) {
       throw new IllegalStateException("수락할 수 없는 초대 상태입니다");
     }
     if (LocalDateTime.now().isAfter(this.expiresAt)) {
       throw new IllegalStateException("만료된 초대입니다");
     }
-    this.status = "ACCEPTED";
+    this.status = InvitationStatus.ACCEPTED;
   }
 
   /**
@@ -102,6 +103,6 @@ public class Invitation {
    * 초대 수락 가능 여부 확인
    */
   public boolean canAccept() {
-    return "PENDING".equals(this.status) && !isExpired();
+    return this.status == InvitationStatus.PENDING && !isExpired();
   }
 }

--- a/src/main/java/com/bifos/accountbook/domain/entity/converter/AbstractCodeEnumConverter.java
+++ b/src/main/java/com/bifos/accountbook/domain/entity/converter/AbstractCodeEnumConverter.java
@@ -43,14 +43,14 @@ public abstract class AbstractCodeEnumConverter<E extends Enum<E> & CodeEnum>
       return null;
     }
 
-    try {
-      return Enum.valueOf(enumClass, dbData);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(
-          String.format("DB 값 '%s'를 %s로 변환할 수 없습니다", dbData, enumClass.getSimpleName()),
-          e
-      );
+    for (E enumValue : enumClass.getEnumConstants()) {
+      if (enumValue.getCode().equals(dbData)) {
+        return enumValue;
+      }
     }
+    throw new IllegalArgumentException(
+        String.format("DB 값 '%s'를 %s로 변환할 수 없습니다", dbData, enumClass.getSimpleName())
+    );
   }
 }
 

--- a/src/main/java/com/bifos/accountbook/domain/entity/converter/FamilyMemberRoleConverter.java
+++ b/src/main/java/com/bifos/accountbook/domain/entity/converter/FamilyMemberRoleConverter.java
@@ -1,0 +1,15 @@
+package com.bifos.accountbook.domain.entity.converter;
+
+import com.bifos.accountbook.domain.value.FamilyMemberRole;
+import jakarta.persistence.Converter;
+
+/**
+ * FamilyMemberRole Enum을 DB 코드값으로 변환하는 Converter
+ */
+@Converter(autoApply = true)
+public class FamilyMemberRoleConverter extends AbstractCodeEnumConverter<FamilyMemberRole> {
+
+  public FamilyMemberRoleConverter() {
+    super(FamilyMemberRole.class);
+  }
+}

--- a/src/main/java/com/bifos/accountbook/domain/entity/converter/InvitationStatusConverter.java
+++ b/src/main/java/com/bifos/accountbook/domain/entity/converter/InvitationStatusConverter.java
@@ -1,0 +1,15 @@
+package com.bifos.accountbook.domain.entity.converter;
+
+import com.bifos.accountbook.domain.value.InvitationStatus;
+import jakarta.persistence.Converter;
+
+/**
+ * InvitationStatus Enum을 DB 코드값으로 변환하는 Converter
+ */
+@Converter(autoApply = true)
+public class InvitationStatusConverter extends AbstractCodeEnumConverter<InvitationStatus> {
+
+  public InvitationStatusConverter() {
+    super(InvitationStatus.class);
+  }
+}

--- a/src/main/java/com/bifos/accountbook/domain/value/FamilyMemberRole.java
+++ b/src/main/java/com/bifos/accountbook/domain/value/FamilyMemberRole.java
@@ -1,0 +1,23 @@
+package com.bifos.accountbook.domain.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 가족 구성원 역할
+ */
+@Getter
+@RequiredArgsConstructor
+public enum FamilyMemberRole implements CodeEnum {
+  /**
+   * 소유자 - 가족을 생성한 관리자
+   */
+  OWNER("owner"),
+
+  /**
+   * 일반 구성원
+   */
+  MEMBER("member");
+
+  private final String code;
+}

--- a/src/main/java/com/bifos/accountbook/domain/value/InvitationStatus.java
+++ b/src/main/java/com/bifos/accountbook/domain/value/InvitationStatus.java
@@ -1,0 +1,23 @@
+package com.bifos.accountbook.domain.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 초대 상태
+ */
+@Getter
+@RequiredArgsConstructor
+public enum InvitationStatus implements CodeEnum {
+  /**
+   * 대기 중 - 수락 대기 상태
+   */
+  PENDING("PENDING"),
+
+  /**
+   * 수락됨 - 초대가 수락된 상태
+   */
+  ACCEPTED("ACCEPTED");
+
+  private final String code;
+}

--- a/src/main/java/com/bifos/accountbook/infra/persistence/repository/impl/InvitationRepositoryImpl.java
+++ b/src/main/java/com/bifos/accountbook/infra/persistence/repository/impl/InvitationRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.bifos.accountbook.infra.persistence.repository.impl;
 import com.bifos.accountbook.domain.entity.Invitation;
 import com.bifos.accountbook.domain.repository.InvitationRepository;
 import com.bifos.accountbook.domain.value.CustomUuid;
+import com.bifos.accountbook.domain.value.InvitationStatus;
 import com.bifos.accountbook.infra.persistence.repository.jpa.InvitationJpaRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -37,12 +38,12 @@ public class InvitationRepositoryImpl implements InvitationRepository {
 
   @Override
   public List<Invitation> findActiveByFamilyUuid(CustomUuid familyUuid, LocalDateTime now) {
-    return jpaRepository.findActiveByFamilyUuid(familyUuid, now);
+    return jpaRepository.findActiveByFamilyUuid(familyUuid, InvitationStatus.PENDING, now);
   }
 
   @Override
   public Optional<Invitation> findValidByToken(String token, LocalDateTime now) {
-    return jpaRepository.findValidByToken(token, now);
+    return jpaRepository.findValidByToken(token, InvitationStatus.PENDING, now);
   }
 
   @Override

--- a/src/main/java/com/bifos/accountbook/infra/persistence/repository/jpa/InvitationJpaRepository.java
+++ b/src/main/java/com/bifos/accountbook/infra/persistence/repository/jpa/InvitationJpaRepository.java
@@ -2,6 +2,7 @@ package com.bifos.accountbook.infra.persistence.repository.jpa;
 
 import com.bifos.accountbook.domain.entity.Invitation;
 import com.bifos.accountbook.domain.value.CustomUuid;
+import com.bifos.accountbook.domain.value.InvitationStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -19,14 +20,16 @@ public interface InvitationJpaRepository extends JpaRepository<Invitation, Long>
 
   Optional<Invitation> findByUuid(CustomUuid uuid);
 
-  @Query("SELECT i FROM Invitation i WHERE i.familyUuid = :familyUuid AND i.status = 'PENDING' AND i.expiresAt > :now")
+  @Query("SELECT i FROM Invitation i WHERE i.familyUuid = :familyUuid AND i.status = :status AND i.expiresAt > :now")
   List<Invitation> findActiveByFamilyUuid(
       @Param("familyUuid") CustomUuid familyUuid,
+      @Param("status") InvitationStatus status,
       @Param("now") LocalDateTime now);
 
-  @Query("SELECT i FROM Invitation i WHERE i.token = :token AND i.status = 'PENDING' AND i.expiresAt > :now")
+  @Query("SELECT i FROM Invitation i WHERE i.token = :token AND i.status = :status AND i.expiresAt > :now")
   Optional<Invitation> findValidByToken(
       @Param("token") String token,
+      @Param("status") InvitationStatus status,
       @Param("now") LocalDateTime now);
 }
 


### PR DESCRIPTION
## Summary
- InvitationStatus Enum 추가 (PENDING, ACCEPTED) + InvitationStatusConverter
- FamilyMemberRole Enum 추가 (OWNER, MEMBER) + FamilyMemberRoleConverter
- AbstractCodeEnumConverter.convertToEntityAttribute: Enum.valueOf → code 기반 검색으로 수정 (lowercase 코드 지원)
- Invitation.status, FamilyMember.role 필드를 String → Enum으로 변경
- InvitationJpaRepository JPQL 스트링 리터럴 → 파라미터 바인딩으로 교체

## Related Issues
closes #88

## Test plan
- [ ] Invitation 생성/수락 흐름 정상 동작 확인
- [ ] FamilyMember role 기반 권한 검증 정상 동작 확인
- [ ] 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)