### PR TITLE
docs(plan001): Family/User CascadeType.ALL → PERSIST+MERGE 전환 계획

### DIFF
--- a/tasks/plan001-fix-cascade-softdelete/index.json
+++ b/tasks/plan001-fix-cascade-softdelete/index.json
@@ -1,0 +1,23 @@
+{
+  "plan": "plan001",
+  "slug": "fix-cascade-softdelete",
+  "title": "Family/User CascadeType.ALL → PERSIST+MERGE 전환 (Soft Delete 충돌 해소)",
+  "issue": "#87",
+  "status": "pending",
+  "phases": [
+    {
+      "id": "phase-01",
+      "title": "cascade 수정 + 테스트 검증",
+      "file": "phase-01.md",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "id": "phase-02",
+      "title": "빌드 검증 + 커밋",
+      "file": "phase-02.md",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan001-fix-cascade-softdelete/phase-01.md
+++ b/tasks/plan001-fix-cascade-softdelete/phase-01.md
@@ -6,20 +6,30 @@ Family/User 엔티티의 `CascadeType.ALL` + `orphanRemoval = true`를 `{Cascade
 
 ## 작업 항목
 
-1. **Family.java 수정** — 3개 `@OneToMany` 관계 (`members`, `incomes`, `expenses`)의 cascade/orphanRemoval 변경
+1. **Family.java 수정** — 3개 `@OneToMany` 관계의 cascade + orphanRemoval 변경
    - 파일: `src/main/java/com/bifos/accountbook/family/domain/entity/Family.java`
-   - 72행: `members` → `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
-   - 76행: `incomes` → 동일 변경
-   - 80행: `expenses` → 동일 변경
+   - 72행 `members`:
+     - `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
+     - `orphanRemoval` 속성 제거 (또는 `false`로 변경)
+   - 76행 `incomes`: 동일 변경
+   - 80행 `expenses`: 동일 변경
 
 2. **User.java 수정** — `familyMembers` 관계 동일 변경
    - 파일: `src/main/java/com/bifos/accountbook/user/domain/entity/User.java`
-   - 79행: `familyMembers` → `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
+   - 79행 `familyMembers`:
+     - `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
+     - `orphanRemoval` 속성 제거 (또는 `false`로 변경)
+   - User 삭제 시 FamilyMember 처리 전략: `status = LEFT`로 soft delete 처리 (FK 제약으로 물리 삭제 방지)
 
-3. **기존 테스트 실행** — 변경 후 전체 테스트 통과 확인
+3. **자식 엔티티 명시적 soft delete 로직 확인**
+   - `FamilyService.deleteFamily()`에서 `family.delete()` 호출 후 members/incomes/expenses 각각 `status = DELETED`로 변경하는 로직이 존재하는지 확인한다.
+   - 누락 시 명시적 soft delete 호출을 추가한다.
+
+4. **기존 테스트 실행** — 변경 후 전체 테스트 통과 확인
    - `./gradlew test --no-daemon --console=plain`
 
 ## 검증 기준
 
 - 전체 테스트 통과 (특히 Family/Expense/Income 관련 테스트)
 - `CascadeType.ALL` / `orphanRemoval = true`가 Family.java, User.java에 남아있지 않음
+- Family/User 삭제 후 자식 레코드가 하드 삭제되지 않고 `status = DELETED`(또는 `LEFT`)로만 변경되는지 테스트로 확인

--- a/tasks/plan001-fix-cascade-softdelete/phase-01.md
+++ b/tasks/plan001-fix-cascade-softdelete/phase-01.md
@@ -1,0 +1,25 @@
+# Phase 01: cascade 수정 + 테스트 검증
+
+## 목표
+
+Family/User 엔티티의 `CascadeType.ALL` + `orphanRemoval = true`를 `{CascadeType.PERSIST, CascadeType.MERGE}`로 변경하여 Soft Delete 정책과의 충돌을 해소한다.
+
+## 작업 항목
+
+1. **Family.java 수정** — 3개 `@OneToMany` 관계 (`members`, `incomes`, `expenses`)의 cascade/orphanRemoval 변경
+   - 파일: `src/main/java/com/bifos/accountbook/family/domain/entity/Family.java`
+   - 72행: `members` → `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
+   - 76행: `incomes` → 동일 변경
+   - 80행: `expenses` → 동일 변경
+
+2. **User.java 수정** — `familyMembers` 관계 동일 변경
+   - 파일: `src/main/java/com/bifos/accountbook/user/domain/entity/User.java`
+   - 79행: `familyMembers` → `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
+
+3. **기존 테스트 실행** — 변경 후 전체 테스트 통과 확인
+   - `./gradlew test --no-daemon --console=plain`
+
+## 검증 기준
+
+- 전체 테스트 통과 (특히 Family/Expense/Income 관련 테스트)
+- `CascadeType.ALL` / `orphanRemoval = true`가 Family.java, User.java에 남아있지 않음

--- a/tasks/plan001-fix-cascade-softdelete/phase-02.md
+++ b/tasks/plan001-fix-cascade-softdelete/phase-02.md
@@ -1,0 +1,17 @@
+# Phase 02: 빌드 검증 + 커밋
+
+## 목표
+
+Checkstyle + 빌드 통과 확인 후 커밋. index.json status를 completed로 마킹.
+
+## 작업 항목
+
+1. **Checkstyle 검증** — `./gradlew checkstyleMain checkstyleTest --no-daemon --console=plain`
+2. **빌드 검증** — `./gradlew build -x integrationTest --no-daemon --console=plain`
+3. **커밋** — `fix(family): CascadeType.ALL → PERSIST+MERGE (Soft Delete 충돌 해소) (#87)`
+4. **index.json status 갱신** — `"status": "completed"` 마킹 + 커밋
+
+## 검증 기준
+
+- Checkstyle + 빌드 + 테스트 모두 통과
+- index.json status가 completed

--- a/tasks/plan001-fix-cascade-softdelete/phase-02.md
+++ b/tasks/plan001-fix-cascade-softdelete/phase-02.md
@@ -8,8 +8,9 @@ Checkstyle + 빌드 통과 확인 후 커밋. index.json status를 completed로 
 
 1. **Checkstyle 검증** — `./gradlew checkstyleMain checkstyleTest --no-daemon --console=plain`
 2. **빌드 검증** — `./gradlew build -x integrationTest --no-daemon --console=plain`
-3. **커밋** — `fix(family): CascadeType.ALL → PERSIST+MERGE (Soft Delete 충돌 해소) (#87)`
-4. **index.json status 갱신** — `"status": "completed"` 마킹 + 커밋
+3. **ADR 업데이트** — `docs/adr.md`에 cascade 변경 근거 및 soft delete 정합성 기록 (ADR-B03 보완 또는 신규 ADR)
+4. **커밋** — `fix(family): CascadeType.ALL → PERSIST+MERGE (Soft Delete 충돌 해소) (#87)`
+5. **index.json status 갱신** — `"status": "completed"` 마킹 + 커밋
 
 ## 검증 기준
 


### PR DESCRIPTION
## Summary

- Family/User 엔티티의 `CascadeType.ALL + orphanRemoval = true`를 `{CascadeType.PERSIST, CascadeType.MERGE}`로 변경하는 계획
- Soft Delete 정책(ADR-B03)과 JPA cascade REMOVE의 충돌 해소 목적
- GitHub Issue #87 대응

## Task Phases

| Phase | 내용 | Model |
|---|---|---|
| phase-01 | cascade 수정 + 테스트 검증 | sonnet |
| phase-02 | 빌드 검증 + 커밋 | haiku |

## Test plan

- [ ] 전체 테스트 통과 (특히 Family/Expense/Income 관련)
- [ ] `CascadeType.ALL` / `orphanRemoval = true`가 Family.java, User.java에 남아있지 않음
- [ ] Checkstyle 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
