### PR TITLE
docs(plan002): NotificationService markAllAsRead 성능 최적화 계획

### DIFF
--- a/tasks/plan002-notification-perf/index.json
+++ b/tasks/plan002-notification-perf/index.json
@@ -1,0 +1,23 @@
+{
+  "plan": "plan002",
+  "slug": "notification-perf",
+  "title": "NotificationService markAllAsRead — 읽지 않은 알림만 조회하도록 최적화",
+  "issue": "#86",
+  "status": "pending",
+  "phases": [
+    {
+      "id": "phase-01",
+      "title": "findUnreadByFamilyAndUser 쿼리 추가 + markAllAsRead 리팩토링 + 테스트 검증",
+      "file": "phase-01.md",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "id": "phase-02",
+      "title": "빌드 검증 + 커밋",
+      "file": "phase-02.md",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan002-notification-perf/phase-01.md
+++ b/tasks/plan002-notification-perf/phase-01.md
@@ -1,0 +1,41 @@
+# Phase 01: findUnreadByFamilyAndUser 쿼리 추가 + markAllAsRead 리팩토링
+
+## 목표
+
+`markAllAsRead()`가 전체 알림(읽은 것 포함)을 로드하는 비효율을 제거한다.
+읽지 않은 알림만 조회하는 쿼리를 추가하고, `markAllAsRead()`에서 사용하도록 변경한다.
+
+## 배경
+
+- `getUnreadCount()`는 이미 DB count 쿼리로 최적화됨 (수정 불필요)
+- `getFamilyNotifications()`는 알림 목록 자체를 전부 로드해야 하므로 메모리 count가 합리적 (수정 불필요)
+- `markAllAsRead()`만 불필요한 전체 로드가 남아있음
+
+## 작업 항목
+
+1. **NotificationJpaRepository에 쿼리 추가**
+   - 파일: `src/main/java/com/bifos/accountbook/notification/infra/repository/jpa/NotificationJpaRepository.java`
+   - 추가: `findAllByFamilyUuidAndUserUuidAndIsReadFalse(familyUuid, userUuid)` JPQL 쿼리
+   - `isRead = false` 조건 + `familyUuid` + `userUuid` 조건
+
+2. **NotificationRepository 인터페이스에 메서드 추가**
+   - 파일: `src/main/java/com/bifos/accountbook/notification/domain/repository/NotificationRepository.java`
+   - 추가: `List<Notification> findUnreadByFamilyAndUser(CustomUuid familyUuid, CustomUuid userUuid)`
+
+3. **NotificationRepositoryImpl에 구현 추가**
+   - 파일: `src/main/java/com/bifos/accountbook/notification/infra/repository/impl/NotificationRepositoryImpl.java`
+   - JPA 쿼리 호출로 위임
+
+4. **NotificationService.markAllAsRead() 수정**
+   - 파일: `src/main/java/com/bifos/accountbook/notification/application/service/NotificationService.java`
+   - 변경 전: `findByFamilyAndUser()` → `stream().filter(!isRead)` (전체 로드 후 메모리 필터)
+   - 변경 후: `findUnreadByFamilyAndUser()` (DB에서 읽지 않은 것만 조회) → 바로 `markAsRead()` 호출
+
+5. **기존 테스트 실행** — 전체 테스트 통과 확인
+   - `./gradlew test --no-daemon --console=plain`
+
+## 검증 기준
+
+- `markAllAsRead()` 테스트 통과 (NotificationControllerTest의 `markAllAsRead_Success`)
+- 전체 테스트 통과
+- `markAllAsRead()` 내에서 `findByFamilyAndUser` 호출이 없어졌는지 코드 확인

--- a/tasks/plan002-notification-perf/phase-02.md
+++ b/tasks/plan002-notification-perf/phase-02.md
@@ -1,0 +1,17 @@
+# Phase 02: 빌드 검증 + 커밋
+
+## 목표
+
+Checkstyle + 빌드 통과 확인 후 커밋. index.json status를 completed로 마킹.
+
+## 작업 항목
+
+1. **Checkstyle 검증** — `./gradlew checkstyleMain checkstyleTest --no-daemon --console=plain`
+2. **빌드 검증** — `./gradlew build -x integrationTest --no-daemon --console=plain`
+3. **커밋** — `perf(notification): markAllAsRead 읽지 않은 알림만 조회하도록 최적화 (#86)`
+4. **index.json status 갱신** — `"status": "completed"` 마킹 + 커밋
+
+## 검증 기준
+
+- Checkstyle + 빌드 + 테스트 모두 통과
+- index.json status가 completed


### PR DESCRIPTION
## Summary

- `markAllAsRead()`가 전체 알림(읽은 것 포함)을 로드하는 비효율 제거
- `findUnreadByFamilyAndUser()` 쿼리 추가하여 읽지 않은 알림만 조회
- `getUnreadCount()`는 이미 DB count 쿼리로 최적화됨 (수정 불필요)
- GitHub Issue #86 대응

## 설계 결정

- bulk UPDATE 대신 엔티티 조회 방식 유지
  - JPA 1차 캐시 일관성 보장
  - 향후 알림 증가 시 페이징 처리로 확장 용이

## Task Phases

| Phase | 내용 | Model |
|---|---|---|
| phase-01 | findUnreadByFamilyAndUser 쿼리 추가 + markAllAsRead 리팩토링 + 테스트 | sonnet |
| phase-02 | 빌드 검증 + 커밋 | haiku |

## Test plan

- [ ] markAllAsRead 테스트 통과
- [ ] 전체 테스트 통과
- [ ] Checkstyle 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
