### PR TITLE
docs(plan004): monthly-trend + category-breakdown stats endpoint 계획

### DIFF
--- a/tasks/plan004-stats-monthly-trend/index.json
+++ b/tasks/plan004-stats-monthly-trend/index.json
@@ -1,0 +1,37 @@
+{
+  "plan": "plan004",
+  "slug": "stats-monthly-trend",
+  "title": "월별 지출 추이 + 카테고리 분포 stats endpoint 추가",
+  "issue": "#126",
+  "status": "pending",
+  "phases": [
+    {
+      "id": "phase-01",
+      "title": "monthly-trend endpoint (DTO + Repository GROUP BY 쿼리 + Service + Controller)",
+      "file": "phase-01.md",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "id": "phase-02",
+      "title": "category-breakdown endpoint (DTO + 전월 delta 로직 + Service + Controller)",
+      "file": "phase-02.md",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "id": "phase-03",
+      "title": "통합 테스트 작성",
+      "file": "phase-03.md",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "id": "phase-04",
+      "title": "빌드 검증 + 커밋",
+      "file": "phase-04.md",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan004-stats-monthly-trend/phase-01.md
+++ b/tasks/plan004-stats-monthly-trend/phase-01.md
@@ -1,0 +1,44 @@
+# Phase 01: monthly-trend endpoint
+
+## 목표
+
+`GET /families/{familyUuid}/dashboard/stats/monthly-trend?from=YYYY-MM&to=YYYY-MM` endpoint를 추가한다.
+단일 GROUP BY 쿼리로 N개월 지출 합계를 집계한다.
+
+## 배경
+
+- 프론트엔드 plan006 (analytics 리디자인)에서 6~12개월 지출 추이 시각화 필요
+- 기존 dashboard 도메인에 이미 월별 통계 패턴 존재 (`getMonthlyExpenseAmount`)
+- 기존 패턴처럼 QueryDSL 사용. `exclude_from_budget` 플래그는 이 쿼리에서 제외 조건 아님 (전체 지출 추이)
+
+## 작업 항목
+
+1. **DTO 생성**
+   - `MonthlyTrendPoint`: `year` (int), `month` (int), `totalExpense` (BigDecimal)
+   - `MonthlyTrendResponse`: `points` (List<MonthlyTrendPoint>), `average` (BigDecimal)
+   - 위치: `dashboard/application/dto/`
+
+2. **DashboardRepository에 메서드 추가**
+   - 인터페이스: `List<MonthlyTrendPoint> getMonthlyExpenseTrend(CustomUuid familyUuid, LocalDateTime from, LocalDateTime to)`
+   - 위치: `dashboard/domain/repository/DashboardRepository.java`
+
+3. **DashboardRepositoryImpl에 QueryDSL 구현**
+   - `SELECT YEAR(e.date), MONTH(e.date), SUM(e.amount) FROM Expense e WHERE e.familyUuid = :familyUuid AND e.status = ACTIVE AND e.date BETWEEN :from AND :to GROUP BY YEAR(e.date), MONTH(e.date) ORDER BY YEAR(e.date), MONTH(e.date)`
+   - 위치: `dashboard/infra/repository/impl/DashboardRepositoryImpl.java`
+   - 기존 `getMonthlyExpenseAmount` QueryDSL 패턴 참조
+
+4. **DashboardService에 메서드 추가**
+   - `getMonthlyTrend(userUuid, familyUuid, fromYearMonth, toYearMonth)`
+   - from/to 파라미터를 LocalDateTime으로 변환
+   - points 평균 계산
+   - `@ValidateFamilyAccess` 적용
+
+5. **DashboardController에 endpoint 추가**
+   - `@GetMapping("/stats/monthly-trend")`
+   - `@RequestParam String from, @RequestParam String to` (YYYY-MM 형식)
+
+## 검증 기준
+
+- endpoint 호출 시 정상 응답
+- 데이터 없는 월은 points에서 제외 (0으로 채우지 않음)
+- average는 points에 있는 월들의 평균

--- a/tasks/plan004-stats-monthly-trend/phase-01.md
+++ b/tasks/plan004-stats-monthly-trend/phase-01.md
@@ -16,6 +16,7 @@
 1. **DTO 생성**
    - `MonthlyTrendPoint`: `year` (int), `month` (int), `totalExpense` (BigDecimal)
    - `MonthlyTrendResponse`: `points` (List<MonthlyTrendPoint>), `average` (BigDecimal)
+     - points가 비어있으면 `average`는 `BigDecimal.ZERO`로 설정 (0 나누기 방어)
    - 위치: `dashboard/application/dto/`
 
 2. **DashboardRepository에 메서드 추가**
@@ -34,8 +35,10 @@
    - `@ValidateFamilyAccess` 적용
 
 5. **DashboardController에 endpoint 추가**
-   - `@GetMapping("/stats/monthly-trend")`
+   - 전체 URL: `GET /api/v1/families/{familyUuid}/dashboard/stats/monthly-trend`
+   - Controller 클래스 레벨 `@RequestMapping("/api/v1/families/{familyUuid}/dashboard")` 에 `@GetMapping("/stats/monthly-trend")` 추가
    - `@RequestParam String from, @RequestParam String to` (YYYY-MM 형식)
+   - 입력 검증: `YearMonth.parse()` 파싱 실패 시 400 Bad Request, `from > to` 역순 시 400 반환
 
 ## 검증 기준
 

--- a/tasks/plan004-stats-monthly-trend/phase-02.md
+++ b/tasks/plan004-stats-monthly-trend/phase-02.md
@@ -29,13 +29,16 @@
 
 4. **DashboardService에 메서드 추가**
    - `getCategoryBreakdown(userUuid, familyUuid, year, month, compareWithPrev)`
-   - `compareWithPrev=true`이면 전월(year, month-1) 데이터도 조회하여 delta 계산
+   - `compareWithPrev=true`이면 전월 데이터도 조회하여 delta 계산
+     - 전월 계산: `YearMonth.of(year, month).minusMonths(1)` 사용 (month=1일 때 전년도 12월 자동 처리)
    - delta = ((현재월 금액 - 전월 금액) / 전월 금액) * 100
    - 전월 해당 카테고리 지출이 0이면 deltaPercent는 null
+   - `totalExpense=0`이면 모든 항목의 `percentage`를 0으로 설정 (0 나누기 방어)
    - `@ValidateFamilyAccess` 적용
 
 5. **DashboardController에 endpoint 추가**
-   - `@GetMapping("/stats/category-breakdown")`
+   - 전체 URL: `GET /api/v1/families/{familyUuid}/dashboard/stats/category-breakdown`
+   - Controller 클래스 레벨 `@RequestMapping("/api/v1/families/{familyUuid}/dashboard")` 에 `@GetMapping("/stats/category-breakdown")` 추가
    - `@RequestParam Integer year, @RequestParam Integer month, @RequestParam(defaultValue = "false") boolean compareWithPrev`
 
 ## 검증 기준

--- a/tasks/plan004-stats-monthly-trend/phase-02.md
+++ b/tasks/plan004-stats-monthly-trend/phase-02.md
@@ -1,0 +1,45 @@
+# Phase 02: category-breakdown endpoint
+
+## 목표
+
+`GET /families/{familyUuid}/dashboard/stats/category-breakdown?year=Y&month=M&compareWithPrev=true` endpoint를 추가한다.
+카테고리별 지출 분포 + 전월 대비 변동률(delta)를 제공한다.
+
+## 배경
+
+- 기존 `getCategoryExpenseStats`가 카테고리별 집계 패턴을 이미 제공
+- delta 계산: 현재 월과 전월을 각각 조회 → 카테고리별 비교
+- `exclude_from_budget` 플래그는 이 쿼리에서 제외 조건 아님 (전체 지출 분포)
+
+## 작업 항목
+
+1. **DTO 생성**
+   - `CategoryBreakdownItem`: `categoryUuid`, `name`, `icon`, `color` (String), `totalAmount` (BigDecimal), `percentage` (Double), `deltaPercent` (Double, nullable)
+   - `CategoryBreakdownResponse`: `year`, `month` (int), `totalExpense` (BigDecimal), `items` (List<CategoryBreakdownItem>)
+   - 위치: `dashboard/application/dto/`
+
+2. **DashboardRepository에 메서드 추가**
+   - `List<CategoryExpenseProjection> getCategoryExpenseStatsByMonth(CustomUuid familyUuid, int year, int month)`
+   - 기존 `getCategoryExpenseStats`와 동일 패턴이나 year/month 조건으로 변경
+   - 위치: `dashboard/domain/repository/DashboardRepository.java`
+
+3. **DashboardRepositoryImpl에 QueryDSL 구현**
+   - 기존 `getCategoryExpenseStats` 구현 참조하여 year/month 조건으로 변경
+   - LEFT JOIN Category + GROUP BY categoryUuid + 금액 내림차순
+
+4. **DashboardService에 메서드 추가**
+   - `getCategoryBreakdown(userUuid, familyUuid, year, month, compareWithPrev)`
+   - `compareWithPrev=true`이면 전월(year, month-1) 데이터도 조회하여 delta 계산
+   - delta = ((현재월 금액 - 전월 금액) / 전월 금액) * 100
+   - 전월 해당 카테고리 지출이 0이면 deltaPercent는 null
+   - `@ValidateFamilyAccess` 적용
+
+5. **DashboardController에 endpoint 추가**
+   - `@GetMapping("/stats/category-breakdown")`
+   - `@RequestParam Integer year, @RequestParam Integer month, @RequestParam(defaultValue = "false") boolean compareWithPrev`
+
+## 검증 기준
+
+- 카테고리별 percentage 합계가 약 100%
+- compareWithPrev=false이면 deltaPercent가 모두 null
+- compareWithPrev=true이면 전월 대비 delta가 계산됨

--- a/tasks/plan004-stats-monthly-trend/phase-03.md
+++ b/tasks/plan004-stats-monthly-trend/phase-03.md
@@ -1,0 +1,26 @@
+# Phase 03: 통합 테스트 작성
+
+## 목표
+
+monthly-trend + category-breakdown endpoint에 대한 Controller 통합 테스트를 작성한다.
+
+## 작업 항목
+
+1. **DashboardController 테스트에 monthly-trend 테스트 추가**
+   - AbstractControllerTest 상속
+   - fixtures로 3개월 분량 지출 데이터 생성
+   - `GET /families/{familyUuid}/dashboard/stats/monthly-trend?from=YYYY-MM&to=YYYY-MM` 호출
+   - points 개수, totalExpense 값, average 검증
+
+2. **DashboardController 테스트에 category-breakdown 테스트 추가**
+   - 2개 이상 카테고리에 지출 데이터 생성
+   - `compareWithPrev=false`: deltaPercent가 null인지 검증
+   - `compareWithPrev=true`: 전월 데이터도 생성 후 delta 값 검증
+
+3. **엣지 케이스 테스트**
+   - 데이터 없는 기간 조회 시 빈 points / items 반환
+   - 전체 테스트 실행: `./gradlew test --no-daemon --console=plain`
+
+## 검증 기준
+
+- 신규 테스트 + 기존 테스트 모두 통과

--- a/tasks/plan004-stats-monthly-trend/phase-04.md
+++ b/tasks/plan004-stats-monthly-trend/phase-04.md
@@ -1,0 +1,17 @@
+# Phase 04: 빌드 검증 + 커밋
+
+## 목표
+
+Checkstyle + 빌드 통과 확인 후 커밋. index.json status를 completed로 마킹.
+
+## 작업 항목
+
+1. **Checkstyle 검증** — `./gradlew checkstyleMain checkstyleTest --no-daemon --console=plain`
+2. **빌드 검증** — `./gradlew build -x integrationTest --no-daemon --console=plain`
+3. **커밋** — `feat(dashboard): monthly-trend + category-breakdown stats endpoint 추가 (#126)`
+4. **index.json status 갱신** — `"status": "completed"` 마킹 + 커밋
+
+## 검증 기준
+
+- Checkstyle + 빌드 + 테스트 모두 통과
+- index.json status가 completed


### PR DESCRIPTION
## Summary

- `GET /families/{uuid}/dashboard/stats/monthly-trend` — N개월 지출 추이 (GROUP BY 집계)
- `GET /families/{uuid}/dashboard/stats/category-breakdown` — 카테고리별 분포 + 전월 delta
- 기존 dashboard 도메인 확장, DB 스키마 변경 없음
- 프론트엔드 plan006 (analytics 리디자인) 지원
- GitHub Issue #126 대응

## Task Phases

| Phase | 내용 | Model |
|---|---|---|
| phase-01 | monthly-trend endpoint (DTO + QueryDSL GROUP BY + Service + Controller) | sonnet |
| phase-02 | category-breakdown endpoint (DTO + 전월 delta + Service + Controller) | sonnet |
| phase-03 | 통합 테스트 작성 | sonnet |
| phase-04 | 빌드 검증 + 커밋 | haiku |

## Test plan

- [ ] monthly-trend: N개월 지출 합계 + 평균 정상 응답
- [ ] category-breakdown: 카테고리별 분포 + percentage 합계 ~100%
- [ ] compareWithPrev=true: 전월 delta 계산 정상
- [ ] 데이터 없는 기간: 빈 응답 반환
- [ ] 전체 테스트 + Checkstyle 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
