### PR TITLE
fix(family): CascadeType.ALL → PERSIST+MERGE (Soft Delete 충돌 해소)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -42,6 +42,15 @@
 
 **적용 엔티티**: User, Family, FamilyMember, Category, Expense, Income, Invitation
 
+**cascade 정책**:
+
+- `@OneToMany` 관계에 `CascadeType.ALL` + `orphanRemoval = true` 사용 금지
+  - orphanRemoval은 컬렉션에서 제거된 자식을 물리 삭제하여 Soft Delete 정책과 충돌한다.
+- 허용 cascade: `{CascadeType.PERSIST, CascadeType.MERGE}`
+- 부모 삭제 시 자식은 Service 계층에서 명시적으로 soft delete 처리한다.
+  - FamilyMember: `status = LEFT`
+  - Expense/Income: `status = DELETED`
+
 ---
 
 ## ADR-B04: JWT 인증 (HS512, 15분/7일)

--- a/src/main/java/com/bifos/accountbook/expense/domain/repository/ExpenseRepository.java
+++ b/src/main/java/com/bifos/accountbook/expense/domain/repository/ExpenseRepository.java
@@ -75,4 +75,9 @@ public interface ExpenseRepository {
    * @param newCategoryUuid 이동 후 카테고리 UUID
    */
   void moveExpenses(CustomUuid oldCategoryUuid, CustomUuid newCategoryUuid);
+
+  /**
+   * 가족의 모든 활성 지출을 DELETED 상태로 벌크 변경
+   */
+  long softDeleteAllByFamilyUuid(CustomUuid familyUuid);
 }

--- a/src/main/java/com/bifos/accountbook/expense/infra/repository/impl/ExpenseRepositoryImpl.java
+++ b/src/main/java/com/bifos/accountbook/expense/infra/repository/impl/ExpenseRepositoryImpl.java
@@ -142,4 +142,14 @@ public class ExpenseRepositoryImpl implements ExpenseRepository {
   public void moveExpenses(CustomUuid oldCategoryUuid, CustomUuid newCategoryUuid) {
     jpaRepository.moveExpenses(oldCategoryUuid, newCategoryUuid);
   }
+
+  @Override
+  public long softDeleteAllByFamilyUuid(CustomUuid familyUuid) {
+    QExpense expense = QExpense.expense;
+    return queryFactory.update(expense)
+        .set(expense.status, ExpenseStatus.DELETED)
+        .where(expense.family.uuid.eq(familyUuid)
+            .and(expense.status.eq(ExpenseStatus.ACTIVE)))
+        .execute();
+  }
 }

--- a/src/main/java/com/bifos/accountbook/family/application/service/FamilyService.java
+++ b/src/main/java/com/bifos/accountbook/family/application/service/FamilyService.java
@@ -140,7 +140,9 @@ public class FamilyService {
                                         .addParameter("familyUuid", familyUuid.getValue()));
 
     family.delete();
-    // 더티 체킹으로 자동 업데이트
+    family.getMembers().forEach(member -> member.leave());
+    family.getExpenses().forEach(expense -> expense.delete());
+    family.getIncomes().forEach(income -> income.delete());
 
     log.info("Deleted family: {} by user: {}", familyUuid, userUuid);
   }

--- a/src/main/java/com/bifos/accountbook/family/application/service/FamilyService.java
+++ b/src/main/java/com/bifos/accountbook/family/application/service/FamilyService.java
@@ -2,6 +2,7 @@ package com.bifos.accountbook.family.application.service;
 
 import com.bifos.accountbook.shared.aop.FamilyValidationService;
 
+import com.bifos.accountbook.expense.domain.repository.ExpenseRepository;
 import com.bifos.accountbook.family.application.dto.CreateFamilyRequest;
 import com.bifos.accountbook.family.application.dto.FamilyResponse;
 import com.bifos.accountbook.family.application.dto.UpdateFamilyRequest;
@@ -17,6 +18,7 @@ import com.bifos.accountbook.user.application.service.UserProfileService;
 import com.bifos.accountbook.user.application.service.UserService;
 import com.bifos.accountbook.shared.value.CustomUuid;
 import com.bifos.accountbook.family.domain.value.FamilyMemberRole;
+import com.bifos.accountbook.income.domain.repository.IncomeRepository;
 import com.bifos.accountbook.shared.aop.FamilyUuid;
 import com.bifos.accountbook.shared.aop.UserUuid;
 import com.bifos.accountbook.shared.aop.ValidateFamilyAccess;
@@ -35,7 +37,9 @@ public class FamilyService {
 
   private final FamilyRepository familyRepository;
   private final FamilyMemberRepository familyMemberRepository;
-  private final UserService userService; // 사용자 조회
+  private final ExpenseRepository expenseRepository;
+  private final IncomeRepository incomeRepository;
+  private final UserService userService;
   private final CategoryService categoryService;
   private final FamilyValidationService familyValidationService;
   private final UserProfileService userProfileService;
@@ -140,9 +144,9 @@ public class FamilyService {
                                         .addParameter("familyUuid", familyUuid.getValue()));
 
     family.delete();
-    family.getMembers().forEach(member -> member.leave());
-    family.getExpenses().forEach(expense -> expense.delete());
-    family.getIncomes().forEach(income -> income.delete());
+    familyMemberRepository.leaveAllByFamilyUuid(familyUuid);
+    expenseRepository.softDeleteAllByFamilyUuid(familyUuid);
+    incomeRepository.softDeleteAllByFamilyUuid(familyUuid);
 
     log.info("Deleted family: {} by user: {}", familyUuid, userUuid);
   }

--- a/src/main/java/com/bifos/accountbook/family/domain/entity/Family.java
+++ b/src/main/java/com/bifos/accountbook/family/domain/entity/Family.java
@@ -69,15 +69,15 @@ public class Family {
   @Builder.Default
   private FamilyStatus status = FamilyStatus.ACTIVE;
 
-  @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "family", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private List<FamilyMember> members = new ArrayList<>();
 
-  @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "family", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private List<Income> incomes = new ArrayList<>();
 
-  @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "family", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private List<Expense> expenses = new ArrayList<>();
 

--- a/src/main/java/com/bifos/accountbook/family/domain/entity/FamilyMember.java
+++ b/src/main/java/com/bifos/accountbook/family/domain/entity/FamilyMember.java
@@ -74,4 +74,8 @@ public class FamilyMember {
       uuid = CustomUuid.generate();
     }
   }
+
+  public void leave() {
+    this.status = FamilyMemberStatus.LEFT;
+  }
 }

--- a/src/main/java/com/bifos/accountbook/family/domain/repository/FamilyMemberRepository.java
+++ b/src/main/java/com/bifos/accountbook/family/domain/repository/FamilyMemberRepository.java
@@ -50,4 +50,9 @@ public interface FamilyMemberRepository {
    * 사용자 UUID로 가족 수 조회 (해당 사용자가 속한 가족 수)
    */
   int countByUserUuid(CustomUuid userUuid);
+
+  /**
+   * 가족의 모든 활성 구성원을 LEFT 상태로 벌크 변경
+   */
+  long leaveAllByFamilyUuid(CustomUuid familyUuid);
 }

--- a/src/main/java/com/bifos/accountbook/family/infra/repository/impl/FamilyMemberRepositoryImpl.java
+++ b/src/main/java/com/bifos/accountbook/family/infra/repository/impl/FamilyMemberRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.bifos.accountbook.family.infra.repository.impl;
 
 import com.bifos.accountbook.family.domain.entity.FamilyMember;
+import com.bifos.accountbook.family.domain.entity.QFamilyMember;
 import com.bifos.accountbook.family.domain.repository.FamilyMemberRepository;
+import com.bifos.accountbook.family.domain.value.FamilyMemberStatus;
 import com.bifos.accountbook.shared.value.CustomUuid;
 import com.bifos.accountbook.family.infra.repository.jpa.FamilyMemberJpaRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Repository;
 public class FamilyMemberRepositoryImpl implements FamilyMemberRepository {
 
   private final FamilyMemberJpaRepository jpaRepository;
+  private final JPAQueryFactory queryFactory;
 
   @Override
   public FamilyMember save(FamilyMember familyMember) {
@@ -57,6 +61,16 @@ public class FamilyMemberRepositoryImpl implements FamilyMemberRepository {
   @Override
   public int countByUserUuid(CustomUuid userUuid) {
     return jpaRepository.countByUserUuid(userUuid);
+  }
+
+  @Override
+  public long leaveAllByFamilyUuid(CustomUuid familyUuid) {
+    QFamilyMember member = QFamilyMember.familyMember;
+    return queryFactory.update(member)
+        .set(member.status, FamilyMemberStatus.LEFT)
+        .where(member.family.uuid.eq(familyUuid)
+            .and(member.status.eq(FamilyMemberStatus.ACTIVE)))
+        .execute();
   }
 }
 

--- a/src/main/java/com/bifos/accountbook/income/domain/repository/IncomeRepository.java
+++ b/src/main/java/com/bifos/accountbook/income/domain/repository/IncomeRepository.java
@@ -58,5 +58,10 @@ public interface IncomeRepository {
       LocalDateTime startDate,
       LocalDateTime endDate,
       Pageable pageable);
+
+  /**
+   * 가족의 모든 활성 수입을 DELETED 상태로 벌크 변경
+   */
+  long softDeleteAllByFamilyUuid(CustomUuid familyUuid);
 }
 

--- a/src/main/java/com/bifos/accountbook/income/infra/repository/impl/IncomeRepositoryImpl.java
+++ b/src/main/java/com/bifos/accountbook/income/infra/repository/impl/IncomeRepositoryImpl.java
@@ -129,5 +129,15 @@ public class IncomeRepositoryImpl implements IncomeRepository {
   private BooleanExpression dateLoe(QIncome income, LocalDateTime endDate) {
     return endDate != null ? income.date.loe(endDate) : null;
   }
+
+  @Override
+  public long softDeleteAllByFamilyUuid(CustomUuid familyUuid) {
+    QIncome income = QIncome.income;
+    return queryFactory.update(income)
+        .set(income.status, IncomeStatus.DELETED)
+        .where(income.family.uuid.eq(familyUuid)
+            .and(income.status.eq(IncomeStatus.ACTIVE)))
+        .execute();
+  }
 }
 

--- a/src/main/java/com/bifos/accountbook/user/domain/entity/User.java
+++ b/src/main/java/com/bifos/accountbook/user/domain/entity/User.java
@@ -76,7 +76,7 @@ public class User {
   @Builder.Default
   private UserStatus status = UserStatus.ACTIVE;
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private List<FamilyMember> familyMembers = new ArrayList<>();
 

--- a/src/test/java/com/bifos/accountbook/family/application/service/FamilyServiceIntegrationTest.java
+++ b/src/test/java/com/bifos/accountbook/family/application/service/FamilyServiceIntegrationTest.java
@@ -4,6 +4,17 @@ import com.bifos.accountbook.family.application.dto.CreateFamilyRequest;
 import com.bifos.accountbook.family.application.dto.FamilyResponse;
 import com.bifos.accountbook.shared.TestFixturesSupport;
 import com.bifos.accountbook.category.domain.entity.Category;
+import com.bifos.accountbook.expense.domain.entity.Expense;
+import com.bifos.accountbook.expense.domain.repository.ExpenseRepository;
+import com.bifos.accountbook.expense.domain.value.ExpenseStatus;
+import com.bifos.accountbook.family.domain.entity.Family;
+import com.bifos.accountbook.family.domain.entity.FamilyMember;
+import com.bifos.accountbook.family.domain.repository.FamilyMemberRepository;
+import com.bifos.accountbook.family.domain.repository.FamilyRepository;
+import com.bifos.accountbook.family.domain.value.FamilyMemberStatus;
+import com.bifos.accountbook.income.domain.entity.Income;
+import com.bifos.accountbook.income.domain.repository.IncomeRepository;
+import com.bifos.accountbook.income.domain.value.IncomeStatus;
 import com.bifos.accountbook.user.domain.entity.User;
 import com.bifos.accountbook.category.domain.repository.CategoryRepository;
 import com.bifos.accountbook.category.domain.value.CategoryStatus;
@@ -27,6 +38,18 @@ class FamilyServiceIntegrationTest extends TestFixturesSupport {
 
   @Autowired
   private CategoryRepository categoryRepository;
+
+  @Autowired
+  private FamilyRepository familyRepository;
+
+  @Autowired
+  private FamilyMemberRepository familyMemberRepository;
+
+  @Autowired
+  private ExpenseRepository expenseRepository;
+
+  @Autowired
+  private IncomeRepository incomeRepository;
 
   @Test
   @DisplayName("가족 생성 시 기본 카테고리 10개가 자동으로 생성되어야 한다")
@@ -200,6 +223,43 @@ class FamilyServiceIntegrationTest extends TestFixturesSupport {
     assertThat(family).isNotNull();
     assertThat(family.getName()).isEqualTo("예산 설정 가족");
     assertThat(family.getMonthlyBudget()).isEqualByComparingTo(budget);
+  }
+
+  @Test
+  @DisplayName("가족 삭제 시 구성원·지출·수입이 물리 삭제 없이 상태만 변경되어야 한다")
+  void deleteFamily_ShouldSoftDeleteChildEntities() {
+    // Given: 서비스로 가족 생성 (OWNER 권한 부여)
+    User user = fixtures.getDefaultUser();
+    CreateFamilyRequest request = CreateFamilyRequest.builder()
+                                                     .name("삭제 테스트 가족")
+                                                     .build();
+    FamilyResponse familyResponse = familyService.createFamily(user.getUuid(), request);
+    CustomUuid familyUuid = CustomUuid.from(familyResponse.getUuid());
+    Family family = familyRepository.findActiveByUuid(familyUuid).orElseThrow();
+
+    // 기본 카테고리에 지출·수입 추가 후 UUID 즉시 저장
+    Category category = fixtures.findCategoryByName(family, "식비");
+    final CustomUuid expenseUuid = fixtures.expenses.expense(family, category).build().getUuid();
+    final CustomUuid incomeUuid = fixtures.incomes.income(family, category).build().getUuid();
+
+    // 삭제 전 구성원 UUID 확보
+    FamilyMember member = familyMemberRepository
+        .findByFamilyUuidAndUserUuid(familyUuid, user.getUuid())
+        .orElseThrow();
+    CustomUuid memberUuid = member.getUuid();
+
+    // When
+    familyService.deleteFamily(user.getUuid(), familyUuid);
+
+    // Then: 물리 삭제 없이 status만 변경됨
+    FamilyMember deletedMember = familyMemberRepository.findByUuid(memberUuid).orElseThrow();
+    assertThat(deletedMember.getStatus()).isEqualTo(FamilyMemberStatus.LEFT);
+
+    Expense deletedExpense = expenseRepository.findByUuid(expenseUuid).orElseThrow();
+    assertThat(deletedExpense.getStatus()).isEqualTo(ExpenseStatus.DELETED);
+
+    Income deletedIncome = incomeRepository.findByUuid(incomeUuid).orElseThrow();
+    assertThat(deletedIncome.getStatus()).isEqualTo(IncomeStatus.DELETED);
   }
 
   @Test

--- a/tasks/plan001-fix-cascade-softdelete/index.json
+++ b/tasks/plan001-fix-cascade-softdelete/index.json
@@ -3,21 +3,21 @@
   "slug": "fix-cascade-softdelete",
   "title": "Family/User CascadeType.ALL → PERSIST+MERGE 전환 (Soft Delete 충돌 해소)",
   "issue": "#87",
-  "status": "pending",
+  "status": "completed",
   "phases": [
     {
       "id": "phase-01",
-      "title": "cascade 수정 + 테스트 검증",
+      "title": "cascade 수정 + 자식 soft delete + 테스트",
       "file": "phase-01.md",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": "phase-02",
       "title": "빌드 검증 + 커밋",
       "file": "phase-02.md",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan001-fix-cascade-softdelete/phase-01.md
+++ b/tasks/plan001-fix-cascade-softdelete/phase-01.md
@@ -1,35 +1,37 @@
-# Phase 01: cascade 수정 + 테스트 검증
+# Phase 01: cascade 수정 + 자식 soft delete + 테스트
 
 ## 목표
 
-Family/User 엔티티의 `CascadeType.ALL` + `orphanRemoval = true`를 `{CascadeType.PERSIST, CascadeType.MERGE}`로 변경하여 Soft Delete 정책과의 충돌을 해소한다.
+Family/User 엔티티의 `CascadeType.ALL` + `orphanRemoval = true`를 `{CascadeType.PERSIST, CascadeType.MERGE}`로 변경하고, 부모 삭제 시 자식을 명시적으로 soft delete 처리한다.
 
 ## 작업 항목
 
 1. **Family.java 수정** — 3개 `@OneToMany` 관계의 cascade + orphanRemoval 변경
    - 파일: `src/main/java/com/bifos/accountbook/family/domain/entity/Family.java`
-   - 72행 `members`:
-     - `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
-     - `orphanRemoval` 속성 제거 (또는 `false`로 변경)
+   - 72행 `members`: `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`, `orphanRemoval` 제거
    - 76행 `incomes`: 동일 변경
    - 80행 `expenses`: 동일 변경
 
 2. **User.java 수정** — `familyMembers` 관계 동일 변경
    - 파일: `src/main/java/com/bifos/accountbook/user/domain/entity/User.java`
-   - 79행 `familyMembers`:
-     - `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`
-     - `orphanRemoval` 속성 제거 (또는 `false`로 변경)
-   - User 삭제 시 FamilyMember 처리 전략: `status = LEFT`로 soft delete 처리 (FK 제약으로 물리 삭제 방지)
+   - 79행 `familyMembers`: `cascade = {CascadeType.PERSIST, CascadeType.MERGE}`, `orphanRemoval` 제거
 
-3. **자식 엔티티 명시적 soft delete 로직 확인**
-   - `FamilyService.deleteFamily()`에서 `family.delete()` 호출 후 members/incomes/expenses 각각 `status = DELETED`로 변경하는 로직이 존재하는지 확인한다.
-   - 누락 시 명시적 soft delete 호출을 추가한다.
+3. **FamilyService.deleteFamily() 보강** — 자식 엔티티 명시적 soft delete 추가
+   - 파일: `src/main/java/com/bifos/accountbook/family/application/service/FamilyService.java`
+   - `family.delete()` 호출 후 아래 로직 추가:
+     - `family.getMembers()` 순회 → 각 member의 `status`를 `FamilyMemberStatus.LEFT`로 변경
+     - `family.getExpenses()` 순회 → 각 expense의 `delete()` 호출 (status = DELETED)
+     - `family.getIncomes()` 순회 → 각 income의 `delete()` 호출 (status = DELETED)
+   - FamilyMember에 `leave()` 메서드가 없으면 추가 (status를 LEFT로 변경)
 
-4. **기존 테스트 실행** — 변경 후 전체 테스트 통과 확인
-   - `./gradlew test --no-daemon --console=plain`
+4. **Family 삭제 시 자식 soft delete 검증 테스트 작성 + 전체 테스트 통과**
+   - `TestFixturesSupport` 상속 Service 테스트로 작성
+   - Family 삭제 후 members/expenses/incomes가 물리 삭제되지 않고 status만 변경되었는지 검증
+   - `./gradlew test --no-daemon --console=plain` 전체 통과 확인
 
 ## 검증 기준
 
-- 전체 테스트 통과 (특히 Family/Expense/Income 관련 테스트)
 - `CascadeType.ALL` / `orphanRemoval = true`가 Family.java, User.java에 남아있지 않음
-- Family/User 삭제 후 자식 레코드가 하드 삭제되지 않고 `status = DELETED`(또는 `LEFT`)로만 변경되는지 테스트로 확인
+- FamilyService.deleteFamily()에서 자식 soft delete 로직이 명시적으로 존재
+- 테스트: Family 삭제 후 자식 레코드가 DB에 존재하며 status가 LEFT/DELETED로 변경됨
+- 전체 테스트 통과

--- a/tasks/plan001-fix-cascade-softdelete/phase-02.md
+++ b/tasks/plan001-fix-cascade-softdelete/phase-02.md
@@ -2,17 +2,14 @@
 
 ## 목표
 
-Checkstyle + 빌드 통과 확인 후 커밋. index.json status를 completed로 마킹.
+Checkstyle + 빌드 통과 확인 후 커밋.
 
 ## 작업 항목
 
 1. **Checkstyle 검증** — `./gradlew checkstyleMain checkstyleTest --no-daemon --console=plain`
 2. **빌드 검증** — `./gradlew build -x integrationTest --no-daemon --console=plain`
-3. **ADR 업데이트** — `docs/adr.md`에 cascade 변경 근거 및 soft delete 정합성 기록 (ADR-B03 보완 또는 신규 ADR)
-4. **커밋** — `fix(family): CascadeType.ALL → PERSIST+MERGE (Soft Delete 충돌 해소) (#87)`
-5. **index.json status 갱신** — `"status": "completed"` 마킹 + 커밋
+3. **커밋** — `fix(family): CascadeType.ALL → PERSIST+MERGE (Soft Delete 충돌 해소) (#87)`
 
 ## 검증 기준
 
 - Checkstyle + 빌드 + 테스트 모두 통과
-- index.json status가 completed


### PR DESCRIPTION
## Summary

- Family/User 엔티티의 `@OneToMany` 관계에서 `CascadeType.ALL` + `orphanRemoval = true`를 `{CascadeType.PERSIST, CascadeType.MERGE}`로 변경
- `FamilyService.deleteFamily()`에 자식 엔티티 명시적 soft delete 로직 추가 (FamilyMember → LEFT, Expense/Income → DELETED)
- `FamilyMember.leave()` 메서드 신규 추가
- ADR-B03에 cascade 정책 섹션 추가 (orphanRemoval 금지, 명시적 soft delete 처리 원칙)

Closes #87

## Test plan

- [x] Family 삭제 시 자식 엔티티가 물리 삭제되지 않고 status만 변경되는지 검증하는 통합 테스트 추가
- [x] 기존 Family/Expense/Income 관련 테스트 전체 통과 확인
- [x] Checkstyle + 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
