### PR TITLE
chore: plan001 완료 상태 업데이트

### DIFF
--- a/tasks/plan001-fix-cascade-softdelete/index.json
+++ b/tasks/plan001-fix-cascade-softdelete/index.json
@@ -3,21 +3,21 @@
   "slug": "fix-cascade-softdelete",
   "title": "Family/User CascadeType.ALL → PERSIST+MERGE 전환 (Soft Delete 충돌 해소)",
   "issue": "#87",
-  "status": "pending",
+  "status": "completed",
   "phases": [
     {
       "id": "phase-01",
-      "title": "cascade 수정 + 테스트 검증",
+      "title": "cascade 수정 + 자식 soft delete + 테스트",
       "file": "phase-01.md",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": "phase-02",
       "title": "빌드 검증 + 커밋",
       "file": "phase-02.md",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `tasks/plan001-fix-cascade-softdelete/index.json`의 status를 `completed`로 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)
