### PR TITLE
fix(ci): 코드 리뷰를 단일 Opus agent + Java/Spring Boot 프롬프트로 전환

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -100,218 +100,50 @@ jobs:
               fi
             done
 
-      - name: Claude 코드 리뷰 실행 (병렬 에이전트 + 인라인 리뷰)
-        # v1 floating tag 가 install.sh 에서 silently 교체된 binary tarball 로 깨진 후
-        # (issue anthropics/claude-code-action#1290, 2026-05-06 회귀) v1.0.111 로 pin.
-        # upstream 픽스 후 다시 v1 으로 풀 것.
+      - name: Claude 코드 리뷰 실행 (단일 Opus agent)
         uses: anthropics/claude-code-action@v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "*"
           prompt: |
-            당신은 fos-accountbook 프로젝트(Next.js 16 App Router 가족 가계부, TypeScript, NextAuth v5, Tailwind CSS v4 + Shadcn) 의 코드 리뷰 orchestrator 입니다.
-            4 개의 병렬 specialist reviewer 를 조율한 뒤 다음을 수행합니다:
-            1. GitHub review API 를 통해 변경된 라인에 인라인 리뷰 댓글 게시 (event: COMMENT)
-            2. 모든 발견사항을 모은 일반 요약 댓글 1 개 게시
+            당신은 fos-accountbook-backend 프로젝트의 코드 리뷰어입니다.
 
-            ## 1단계: PR 데이터 수집
+            ## 프로젝트 정보
 
-            먼저 다음 명령을 실행한다 (lock 파일과 snapshot 은 noise 감소를 위해 diff 에서 제외됨):
+            - Spring Boot 4, Java 21, JPA + QueryDSL, JWT 인증, Flyway 마이그레이션
+            - 도메인 기반 패키지: presentation(Controller) → application(Service) → domain(Entity/Repository) → infra(JPA 구현)
+            - Google Java Style + Naver Convention (Checkstyle 자동 검사)
+
+            ## PR 데이터 수집
+
             ```
             gh pr diff ${{ env.PR_NUMBER }} --repo ${{ github.repository }} -- ':!gradle/wrapper/gradle-wrapper.jar' ':!*.lock' ':!build/' ':!*.class'
             gh pr view ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --json title,body,additions,deletions
             ```
 
-            필터링 후 diff 가 비어 있으면 짧은 긍정 댓글을 게시하고 종료한다.
+            diff 가 비어 있으면 짧은 긍정 댓글을 게시하고 종료한다.
 
-            ## 2단계: 4 개 병렬 specialist 에이전트 spawn
+            ## 리뷰 관점 (4가지 축)
 
-            Agent tool 을 사용해 4 개 에이전트를 **동시에** 실행한다.
-            **각 에이전트는 반드시 `model: "haiku"` 를 사용** 해 토큰 사용을 최소화한다.
-            각 에이전트의 prompt 에 필터링된 전체 diff 를 전달한다.
+            ### 1. Java & JPA 정확성
+            🔴 Entity @Data 사용, 쓰기 메서드 @Transactional 누락, AOP 자기 호출(@CacheEvict/@Transactional 같은 클래스 내 호출), BigDecimal == 비교, N+1 쿼리 위험
+            🟡 Optional.get() 직접 호출, 와일드카드 import
 
-            각 에이전트는 반드시 다음 EXACT 구조로 발견사항을 포맷한다 (parse-friendly):
+            ### 2. 프로젝트 컨벤션
+            🔴 System.out.println (Slf4j 필수), Controller 에서 Entity 직접 반환 (DTO 필수), 한국어 발음 식별자
+            🟡 매직 넘버, DTO 에 Setter
 
-            ```
-            FINDING_START
-            TYPE: INLINE
-            SEVERITY: 🔴
-            PATH: src/components/foo.tsx
-            LINE: 42
-            ISSUE: 문제 설명 (한국어)
-            FIX: 수정 제안 (한국어)
-            FINDING_END
+            ### 3. 보안 & 권한
+            🔴 가족 리소스에 familyUuid URL 누락, @ValidateFamilyAccess 누락, SQL Injection, 민감 정보 로깅
+            🟡 @LoginUser 없이 사용자 식별, skipAuth endpoint 에서 민감 데이터 노출
 
-            FINDING_START
-            TYPE: GENERAL
-            SEVERITY: 🟡
-            ISSUE: 특정 라인을 꼬집기 어려운 일반적인 문제 (한국어)
-            FIX: 수정 제안 (한국어)
-            FINDING_END
-            ```
+            ### 4. 아키텍처 & Spring 패턴
+            🔴 Controller→Repository 직접 주입, 레이어 역방향 의존성, 기존 Flyway 마이그레이션 수정
+            🟡 Service 과다 의존, 테스트 @Transactional 사용, Service/Repository 모킹
 
-            TYPE 선택 규칙:
-            - diff 에서 정확한 파일 경로와 라인 번호를 식별 가능할 때만 `TYPE: INLINE` 사용
-            - PATH 는 diff 와 매치되는 상대 경로 (예: `src/components/foo.tsx`)
-            - LINE 은 NEW 파일 (diff 의 RIGHT 측, `+` 또는 context 라인) 의 실제 라인 번호
-            - 여러 파일에 걸치거나 단일 라인을 특정 못 하는 경우 `TYPE: GENERAL` 사용
-            - 발견사항이 전혀 없으면 `NO_ISSUES` 출력
+            ## 출력
 
-            ---
-
-            **Agent 1 — TypeScript & Type Safety** (`model: "haiku"`)
-
-            Prompt:
-            ```
-            당신은 TypeScript specialist reviewer 입니다. 이 PR diff 를 타입 안전성 이슈만 분석한다.
-
-            PR DIFF:
-            <여기에 전체 diff 삽입>
-
-            확인 항목:
-            - `any` 타입 사용 (명시적 또는 암시적)
-            - 런타임에 null/undefined 가능한 non-nullable 타입 (optional chaining 누락)
-            - 안전성을 우회하는 타입 단언 (`as X`)
-            - Server Action 또는 async 함수의 잘못된 반환 타입
-            - 실제 API 응답 형태와 일치 안 하는 타입 정의
-
-            각 발견사항을 다음 형식 그대로 출력한다:
-
-            FINDING_START
-            TYPE: INLINE or GENERAL
-            SEVERITY: 🔴 or 🟡
-            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
-            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
-            ISSUE: 한국어로 문제 설명
-            FIX: 한국어로 수정 제안
-            FINDING_END
-
-            발견사항이 없으면 `NO_ISSUES` 출력.
-            ```
-
-            ---
-
-            **Agent 2 — Project Conventions** (`model: "haiku"`)
-
-            Prompt:
-            ```
-            당신은 코드 컨벤션 specialist 입니다. 이 PR diff 를 컨벤션 위반만 분석한다.
-
-            PR DIFF:
-            <여기에 전체 diff 삽입>
-
-            🔴 필수 수정:
-            - JSX/TSX 의 하드코딩 색상 (`from-blue-500`, `#hexcolor`, `bg-white/20`)
-              → 시맨틱 클래스 사용: gradient-expense, gradient-income, gradient-budget, gradient-primary 등
-            - hex/rgb/hsl 직접 작성 (ADR-F13: OKLCH 토큰만)
-            - `alert()`, `confirm()`, `prompt()` → sonner `toast` 사용
-            - 프로덕션 코드의 `console.log`
-            - `.dark` 클래스 신규 추가 (ADR-F15: `[data-theme="dark"]` 만)
-
-            🟡 권장 수정:
-            - 클라이언트 컴포넌트의 `console.error` (사용자 피드백 state 없이 단독)
-            - Tailwind 클래스로 표현 가능한 inline `style={{ }}` (단일 토큰은 `text-[var(--token)]` arbitrary class)
-            - 상수로 추출해야 할 매직 넘버/문자열
-
-            각 발견사항을 다음 형식 그대로 출력한다:
-
-            FINDING_START
-            TYPE: INLINE or GENERAL
-            SEVERITY: 🔴 or 🟡
-            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
-            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
-            ISSUE: 한국어로 문제 설명
-            FIX: 한국어로 수정 제안
-            FINDING_END
-
-            발견사항이 없으면 `NO_ISSUES` 출력.
-            ```
-
-            ---
-
-            **Agent 3 — Security & Authorization** (`model: "haiku"`)
-
-            Prompt:
-            ```
-            당신은 security specialist 입니다. 이 PR diff 를 보안 이슈만 분석한다.
-
-            PR DIFF:
-            <여기에 전체 diff 삽입>
-
-            확인 항목:
-            🔴 필수 수정:
-            - Server Action 시작에 `requireAuth()` 또는 `requireAuthOrRedirect()` 누락
-            - 클라이언트 컴포넌트에서 `NEXT_PUBLIC_` prefix 없는 환경변수 사용 (시크릿 노출)
-            - 검증 안 된 외부 입력이 외부 API 또는 DB 쿼리에 직접 전달
-            - 권한 검증 누락 (사용자가 다른 가족의 데이터 접근 가능)
-
-            🟡 권장 수정:
-            - 폼 제출 / API 경계에서 Zod 검증 누락 (ADR-F06)
-            - 민감 데이터 (토큰, 가족 uuid 등) 가 console 에 로깅됨
-
-            각 발견사항을 다음 형식 그대로 출력한다:
-
-            FINDING_START
-            TYPE: INLINE or GENERAL
-            SEVERITY: 🔴 or 🟡
-            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
-            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
-            ISSUE: 한국어로 문제 설명
-            FIX: 한국어로 수정 제안
-            FINDING_END
-
-            발견사항이 없으면 `NO_ISSUES` 출력.
-            ```
-
-            ---
-
-            **Agent 4 — Architecture & Next.js Patterns** (`model: "haiku"`)
-
-            Prompt:
-            ```
-            당신은 Next.js architecture specialist 입니다. 이 PR diff 를 아키텍처 이슈만 분석한다.
-
-            PR DIFF:
-            <여기에 전체 diff 삽입>
-
-            이 프로젝트는 Next.js 16 App Router + 계층형 아키텍처를 사용한다:
-            Page → Action (auth/Zod/revalidatePath) → Service (API 호출) → lib/server/api
-
-            🔴 필수 수정:
-            - Server Component 에서 React hooks (useState, useEffect, useRouter 등) 사용 ("use client" 누락)
-            - Client Component 에 server-only 코드 (백엔드 토큰 사용, requireAuth 등)
-            - "use client" 또는 "use server" directive 가 파일 첫 줄에 위치하지 않음
-            - Action 레이어에 비즈니스 로직 (API 호출) 혼재 — Service 책임 위반 (ADR-F04)
-            - Service 레이어에서 `revalidatePath` / `requireAuth` 호출 (ADR-F04)
-            - Page (Server Component) 에서 `serverApiGet` 직접 호출 (ADR-F12: Action 경유 필수)
-
-            🟡 권장 수정:
-            - hooks/이벤트 핸들러 없는 컴포넌트의 불필요한 "use client" (Server Component 여야 함)
-            - Server Component 로 처리 가능한데 Client Component 에서 데이터 fetch
-            - 신규 라우트의 loading.tsx 또는 error.tsx 누락
-            - 다이얼로그 재오픈 시 stale form state
-
-            각 발견사항을 다음 형식 그대로 출력한다:
-
-            FINDING_START
-            TYPE: INLINE or GENERAL
-            SEVERITY: 🔴 or 🟡
-            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
-            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
-            ISSUE: 한국어로 문제 설명
-            FIX: 한국어로 수정 제안
-            FINDING_END
-
-            발견사항이 없으면 `NO_ISSUES` 출력.
-            ```
-
-            ## 3단계: 인라인 리뷰 댓글 게시
-
-            4 개 에이전트 완료 후 모든 FINDING_START/FINDING_END 블록을 수집하고 중복 제거한다.
-
-            모든 `TYPE: INLINE` 발견사항을 모아 단일 GitHub PR review 를 만든다.
-
-            JSON 을 구성하고 다음 명령 실행 (comments 배열은 실제 파싱한 발견사항으로 교체):
+            ### 인라인 리뷰 (발견사항이 있을 때만)
 
             ```bash
             gh api repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews \
@@ -322,7 +154,7 @@ jobs:
               "event": "COMMENT",
               "comments": [
                 {
-                  "path": "src/components/foo.tsx",
+                  "path": "src/main/java/.../SomeFile.java",
                   "line": 42,
                   "side": "RIGHT",
                   "body": "🔴 **문제**: ...\n\n**수정**: ..."
@@ -332,49 +164,16 @@ jobs:
             REVIEW_EOF
             ```
 
-            각 인라인 댓글 body 포맷:
-            `{SEVERITY} **문제**: {ISSUE}\n\n**수정**: {FIX}`
+            규칙:
+            - `event` 는 항상 `"COMMENT"` (머지 차단 방지)
+            - `path` 는 diff 와 정확히 매치되는 상대 경로
+            - `line` 불확실하면 인라인 대신 요약에만 포함
+            - 인라인 발견사항이 없으면 이 단계 skip
 
-            중요 규칙:
-            - `event` 는 항상 `"COMMENT"` (REQUEST_CHANGES 사용 안 함 — 머지 차단 방지, 리뷰는 권고)
-            - `path` 는 diff 와 정확히 매치되는 상대 경로 (앞에 `/` 추가 금지)
-            - `line` 은 해당 파일의 diff 에 등장하는 숫자여야 함 — 불확실하면 GENERAL 로 처리
-            - `side` 는 항상 `"RIGHT"` (NEW 파일 측)
-            - 인라인 발견사항이 없으면 이 단계 전체 skip
-            - `gh api` 호출이 실패하면 (예: 422 invalid line) 에러를 로그하고 재시도 없이 4단계로 진행
-
-            ## 4단계: 일반 요약 댓글 게시
-
-            모든 발견사항 (INLINE + GENERAL) 을 포함하는 일반 요약 댓글을 정확히 1 개 게시한다.
-
-            **CRITICAL — body 전달 방식**: 반드시 `--body-file -` + HEREDOC 패턴을 사용한다.
-            `--body "...\n..."` 처럼 큰따옴표 안에 `\n` escape 를 쓰면 shell 이 literal 두 글자
-            (`\` + `n`) 그대로 GitHub API 에 전달해 댓글 본문이 깨진다 (실제 줄바꿈으로 렌더 안 됨).
+            ### 요약 댓글 (반드시 1개)
 
             ```bash
             gh pr comment ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --body-file - <<'COMMENT_EOF'
-            ## 코드 리뷰 [PR 제목 요약]
-
-            [한 줄 전체 평가]
-
-            ---
-
-            ### 🔴 머지 전 필수 수정 (있는 경우만)
-
-            ...
-
-            (이하 요약 댓글 포맷 그대로 — 실제 줄바꿈으로 작성)
-            COMMENT_EOF
-            ```
-
-            HEREDOC 안에서는 `\n` escape 없이 **실제 newline** 만 사용한다. backtick 코드 블록,
-            한국어, 이모지 모두 `'COMMENT_EOF'` (single-quoted) 안에서 안전하게 통과.
-
-            ## 요약 댓글 포맷
-
-            한국어로 작성. 다음 구조 그대로 사용:
-
-            ```
             ## 코드 리뷰 [PR 제목 요약]
 
             [한 줄 전체 평가]
@@ -398,36 +197,21 @@ jobs:
             - ...
 
             ---
-            🤖 Reviewed with [Claude Code](https://claude.com/claude-code) (Sonnet orchestrator · Haiku specialists: TypeScript · Conventions · Security · Architecture)
+            🤖 Reviewed with [Claude Code](https://claude.com/claude-code) (Opus)
             💬 인라인 코멘트는 **Files changed** 탭에서 확인하세요
+            COMMENT_EOF
             ```
 
             ## 핵심 규칙
 
-            - **PR 브랜치에 어떠한 파일도 git add / commit / push 금지** — review 작업은 read-only +
-              GitHub API 호출만. 임시 파일 (예: `.claude-pr/summary.md`) 도 만들지 말 것. 요약 댓글은
-              반드시 `gh pr comment ... --body-file - <<'COMMENT_EOF' ... COMMENT_EOF` HEREDOC 으로
-              stdin 전달만 사용. 디스크에 파일을 만든 후 읽는 패턴 금지 (action wrapper 의 `git add -A`
-              가 그 파일을 PR 브랜치 commit 으로 흘려보냄 — fos-blog PR #83 실제 사고).
-            - **테스트 / 더미 / placeholder 댓글 게시 절대 금지** — 실제 production 리뷰임.
-              사용자 토큰 낭비 + review-fix 흐름 오염. 게시 직전 다음 sanity check 통과해야 한다:
-              - body 가 specialist agent FINDING 의 `🔴`/`🟡` + `**문제**:` + `**수정**:` 패턴을 모두 포함하는가?
-              - body 에 `test body`, `test 1`, `sample`, `placeholder`, `example`, `<여기에>`,
-                `{ISSUE}`, `{FIX}` 같은 dummy / template 잔재가 없는가?
-              - body 가 12자 미만이거나 의미 있는 한국어 문장 0개면 reject
-              위 셋 중 하나라도 실패하는 entry 는 즉시 제거 후 게시. comments 배열이 비면 3단계
-              review 게시 자체 skip + 4단계 일반 요약 댓글에 "발견사항 없음 — 인라인 review skip"
-              한 줄로 갈음 (fos-blog PR #114 실제 사고).
-            - **일반 댓글은 정확히 1 개만 게시** (4단계) — `gh pr comment` 를 두 번 이상 호출 금지
-            - **인라인 리뷰 (3단계) 와 일반 댓글 (4단계) 은 분리** — 발견사항이 있으면 둘 다 게시
-            - **내용이 있는 섹션만 포함** — 비어 있는 🔴 또는 🟡 섹션은 완전히 생략
-            - **구체적으로 작성** — 정확한 파일명과 라인 번호 참조
-            - **이슈가 0 개면** 3단계 skip 후 4단계에서 🟢 섹션만 있는 짧은 긍정 댓글 작성
-            - **일반 댓글 작성 시 반드시 `--body-file -` HEREDOC 사용** — `--body "...\n..."` 는
-              shell 이 `\n` 을 literal 로 처리해 댓글 포매팅이 깨진다 (4단계의 CRITICAL 참조).
-              3단계의 인라인 review JSON body 안의 `\n` 은 JSON parser 가 해석하므로 정상.
+            - **PR 브랜치에 파일 생성/수정/커밋 금지** — read-only + GitHub API 호출만
+            - **요약 댓글은 반드시 `--body-file -` HEREDOC 사용** — `--body "..."` 는 `\n` 이 깨짐
+            - **일반 댓글은 정확히 1개만** — `gh pr comment` 두 번 이상 호출 금지
+            - **이슈 0개면** 인라인 skip + 🟢 섹션만 있는 짧은 긍정 댓글
+            - **비어 있는 🔴/🟡 섹션은 완전히 생략**
+            - **테스트/더미/placeholder 댓글 게시 금지**
 
-          claude_args: '--model claude-sonnet-4-6 --allowedTools "Agent,Bash" --disallowedTools "Read,Write,Edit,Glob,Grep,LS"'
+          claude_args: '--model claude-opus-4-7 --allowedTools "Bash" --disallowedTools "Agent,Read,Write,Edit,Glob,Grep,LS"'
 
       # 게시된 댓글 본문에 literal `\n` 두 글자가 박힌 경우 자동 보정.
       # 사고 패턴: Claude action 이 prompt 의 `--body-file - <<'COMMENT_EOF'` HEREDOC


### PR DESCRIPTION
## Summary

- 프론트엔드(Next.js/TypeScript) 전용 리뷰 프롬프트 → Java/Spring Boot 프로젝트에 맞게 재작성
- Sonnet orchestrator + 4개 Haiku specialist → **단일 Opus agent**로 단순화
- 프롬프트 260줄 → 42줄 (커뮤니티 표준에 맞춤)
- Agent tool 비활성화로 sub-agent spawn 방지

### 변경 전후 비교

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 구조 | Sonnet orchestrator + 4 Haiku specialists | 단일 Opus agent |
| 프롬프트 | Next.js/TypeScript 전용 260줄 | Java/Spring Boot 4축 42줄 |
| 도구 | Agent + Bash 허용 | Bash만 허용 (Agent 비활성화) |
| 리뷰 축 | TypeScript, JSX/Tailwind, Next.js Security, Next.js Patterns | Java/JPA, Conventions, Security, Architecture |

## Test plan

- [ ] 다음 PR에서 Opus 단일 agent 리뷰 정상 동작
- [ ] Java/Spring Boot 관련 발견사항 생성
- [ ] TypeScript/Next.js 무의미한 지적 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
