### PR TITLE
perf(notification): markAllAsRead 읽지 않은 알림만 조회하도록 최적화 (#86)

### DIFF
--- a/src/main/java/com/bifos/accountbook/notification/application/service/NotificationService.java
+++ b/src/main/java/com/bifos/accountbook/notification/application/service/NotificationService.java
@@ -116,12 +116,8 @@ public class NotificationService {
   @ValidateFamilyAccess
   @Transactional
   public void markAllAsRead(@UserUuid CustomUuid userUuid, @FamilyUuid CustomUuid familyUuid) {
-    // 현재 사용자의 읽지 않은 알림만 조회
     List<Notification> notifications = notificationRepository
-        .findByFamilyAndUser(familyUuid, userUuid)
-        .stream()
-        .filter(n -> !n.getIsRead())
-        .collect(Collectors.toList());
+        .findUnreadByFamilyAndUser(familyUuid, userUuid);
 
     for (Notification notification : notifications) {
       notification.markAsRead();

--- a/src/main/java/com/bifos/accountbook/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/bifos/accountbook/notification/domain/repository/NotificationRepository.java
@@ -61,6 +61,11 @@ public interface NotificationRepository {
   List<Notification> findByFamilyAndUser(CustomUuid familyUuid, CustomUuid userUuid);
 
   /**
+   * 가족 내 특정 사용자의 읽지 않은 알림 조회
+   */
+  List<Notification> findUnreadByFamilyAndUser(CustomUuid familyUuid, CustomUuid userUuid);
+
+  /**
    * 가족 내 특정 사용자의 읽지 않은 알림 수
    */
   long countUnreadByFamilyAndUser(CustomUuid familyUuid, CustomUuid userUuid);

--- a/src/main/java/com/bifos/accountbook/notification/infra/repository/impl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/bifos/accountbook/notification/infra/repository/impl/NotificationRepositoryImpl.java
@@ -70,6 +70,11 @@ public class NotificationRepositoryImpl implements NotificationRepository {
   }
 
   @Override
+  public List<Notification> findUnreadByFamilyAndUser(CustomUuid familyUuid, CustomUuid userUuid) {
+    return jpaRepository.findAllByFamilyUuidAndUserUuidAndIsReadFalse(familyUuid, userUuid);
+  }
+
+  @Override
   public long countUnreadByFamilyAndUser(CustomUuid familyUuid, CustomUuid userUuid) {
     return jpaRepository.countByFamilyUuidAndUserUuidAndIsReadFalse(familyUuid, userUuid);
   }

--- a/src/main/java/com/bifos/accountbook/notification/infra/repository/jpa/NotificationJpaRepository.java
+++ b/src/main/java/com/bifos/accountbook/notification/infra/repository/jpa/NotificationJpaRepository.java
@@ -70,6 +70,14 @@ public interface NotificationJpaRepository extends JpaRepository<Notification, L
       @Param("familyUuid") CustomUuid familyUuid,
       @Param("userUuid") CustomUuid userUuid);
 
+  @Query("SELECT n FROM Notification n " +
+      "WHERE n.familyUuid = :familyUuid " +
+      "AND n.userUuid = :userUuid " +
+      "AND n.isRead = false")
+  List<Notification> findAllByFamilyUuidAndUserUuidAndIsReadFalse(
+      @Param("familyUuid") CustomUuid familyUuid,
+      @Param("userUuid") CustomUuid userUuid);
+
   @Modifying
   @Query("DELETE FROM Notification n WHERE n.createdAt < :dateTime")
   void deleteByCreatedAtBefore(@Param("dateTime") LocalDateTime dateTime);

--- a/tasks/plan002-notification-perf/index.json
+++ b/tasks/plan002-notification-perf/index.json
@@ -3,21 +3,21 @@
   "slug": "notification-perf",
   "title": "NotificationService markAllAsRead — 읽지 않은 알림만 조회하도록 최적화",
   "issue": "#86",
-  "status": "pending",
+  "status": "completed",
   "phases": [
     {
       "id": "phase-01",
       "title": "findUnreadByFamilyAndUser 쿼리 추가 + markAllAsRead 리팩토링 + 테스트 검증",
       "file": "phase-01.md",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": "phase-02",
       "title": "빌드 검증 + 커밋",
       "file": "phase-02.md",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `markAllAsRead()`가 전체 알림(읽은 것 포함)을 로드하는 비효율 제거
- `findUnreadByFamilyAndUser()` 쿼리 추가하여 읽지 않은 알림만 조회
- GitHub Issue #86 대응

## 변경 파일

- `NotificationJpaRepository` — `findAllByFamilyUuidAndUserUuidAndIsReadFalse` JPQL 쿼리 추가
- `NotificationRepository` — `findUnreadByFamilyAndUser` 인터페이스 메서드 추가
- `NotificationRepositoryImpl` — 구현 추가
- `NotificationService` — `markAllAsRead()` 내부 로직 최적화

## 설계 결정

- bulk UPDATE 대신 엔티티 조회 방식 유지
  - JPA 1차 캐시 일관성 보장
  - 예산 알림은 최대 3종(50%/80%/100%)이므로 성능 손실 미미

## Test plan

- [x] markAllAsRead 테스트 통과
- [x] 전체 테스트 통과
- [x] Checkstyle 통과
- [x] 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
