### PR TITLE
feat(expense): 월별 지출내역 CSV 내보내기 endpoint 추가 (#59)

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -52,6 +52,7 @@
 - 카테고리, 날짜 범위, 사용자별 필터링 (페이징)
 - 지출: `exclude_from_budget` 플래그로 예산 집계 제외 가능
 - Soft Delete (ACTIVE → DELETED)
+- 월별 지출내역 CSV 내보내기 (BOM 포함, RFC 4180 준수)
 
 ### F4. 카테고리
 

--- a/src/main/java/com/bifos/accountbook/expense/application/service/ExpenseService.java
+++ b/src/main/java/com/bifos/accountbook/expense/application/service/ExpenseService.java
@@ -24,6 +24,7 @@ import com.bifos.accountbook.shared.aop.ValidateFamilyAccess;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -269,7 +270,7 @@ public class ExpenseService {
 
     LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0, 0);
     LocalDateTime end = start.with(TemporalAdjusters.lastDayOfMonth())
-        .withHour(23).withMinute(59).withSecond(59);
+        .with(LocalTime.MAX);
 
     List<Expense> expenses = expenseRepository.findByFamilyUuidAndDateBetween(
         familyUuid, start, end);
@@ -284,7 +285,11 @@ public class ExpenseService {
         categoryName = categoryService.findByUuidCached(familyUuid, expense.getCategoryUuid())
             .getName();
       } catch (BusinessException e) {
-        categoryName = "미분류";
+        if (e.getErrorCode() == ErrorCode.CATEGORY_NOT_FOUND) {
+          categoryName = "미분류";
+        } else {
+          throw e;
+        }
       }
 
       csv.append(expense.getDate().toLocalDate())

--- a/src/main/java/com/bifos/accountbook/expense/application/service/ExpenseService.java
+++ b/src/main/java/com/bifos/accountbook/expense/application/service/ExpenseService.java
@@ -22,7 +22,10 @@ import com.bifos.accountbook.shared.aop.FamilyUuid;
 import com.bifos.accountbook.shared.aop.UserUuid;
 import com.bifos.accountbook.shared.aop.ValidateFamilyAccess;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -251,6 +254,61 @@ public class ExpenseService {
     }
 
     return ExpenseResponse.fromWithoutCategory(expense);
+  }
+
+  /**
+   * 월별 지출내역 CSV 생성
+   * BOM 포함 (Excel 한글 깨짐 방지), RFC 4180 준수
+   */
+  @ValidateFamilyAccess
+  public byte[] exportMonthlyExpenseCsv(
+      @UserUuid CustomUuid userUuid,
+      @FamilyUuid CustomUuid familyUuid,
+      int year,
+      int month) {
+
+    LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0, 0);
+    LocalDateTime end = start.with(TemporalAdjusters.lastDayOfMonth())
+        .withHour(23).withMinute(59).withSecond(59);
+
+    List<Expense> expenses = expenseRepository.findByFamilyUuidAndDateBetween(
+        familyUuid, start, end);
+
+    StringBuilder csv = new StringBuilder();
+    csv.append('\uFEFF');
+    csv.append("날짜,카테고리,금액,설명\r\n");
+
+    for (Expense expense : expenses) {
+      String categoryName;
+      try {
+        categoryName = categoryService.findByUuidCached(familyUuid, expense.getCategoryUuid())
+            .getName();
+      } catch (BusinessException e) {
+        categoryName = "미분류";
+      }
+
+      csv.append(expense.getDate().toLocalDate())
+          .append(",")
+          .append(escapeCsvField(categoryName))
+          .append(",")
+          .append(expense.getAmount().toPlainString())
+          .append(",")
+          .append(escapeCsvField(expense.getDescription()))
+          .append("\r\n");
+    }
+
+    return csv.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  private String escapeCsvField(String field) {
+    if (field == null) {
+      return "";
+    }
+    if (field.contains(",") || field.contains("\n") || field.contains("\r")
+        || field.contains("\"")) {
+      return "\"" + field.replace("\"", "\"\"") + "\"";
+    }
+    return field;
   }
 
   /**

--- a/src/main/java/com/bifos/accountbook/expense/presentation/controller/ExpenseController.java
+++ b/src/main/java/com/bifos/accountbook/expense/presentation/controller/ExpenseController.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,7 +33,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "지출 (Expense)", description = "지출 내역 관리 API")

--- a/src/main/java/com/bifos/accountbook/expense/presentation/controller/ExpenseController.java
+++ b/src/main/java/com/bifos/accountbook/expense/presentation/controller/ExpenseController.java
@@ -16,9 +16,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "지출 (Expense)", description = "지출 내역 관리 API")
@@ -37,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/families/{familyUuid}/expenses")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "bearerAuth")
+@Validated
 public class ExpenseController {
 
   private final ExpenseService expenseService;
@@ -105,6 +110,28 @@ public class ExpenseController {
     ExpenseResponse response = expenseService.updateExpense(loginUser.userUuid(), familyUuid, expenseUuid, request);
 
     return ResponseEntity.ok(ApiSuccessResponse.of("지출이 수정되었습니다", response));
+  }
+
+  @Operation(summary = "월별 지출내역 CSV 내보내기", description = "해당 월의 지출내역을 CSV 파일로 다운로드합니다.")
+  @ApiResponse(responseCode = "200", description = "다운로드 성공")
+  @ApiResponse(responseCode = "403", description = "접근 권한 없음")
+  @GetMapping("/export")
+  public ResponseEntity<byte[]> exportExpensesCsv(
+      @LoginUser LoginUserDto loginUser,
+      @PathVariable CustomUuid familyUuid,
+      @RequestParam @Min(1900) @Max(2100) Integer year,
+      @RequestParam @Min(1) @Max(12) Integer month) {
+
+    byte[] csv = expenseService.exportMonthlyExpenseCsv(
+        loginUser.userUuid(), familyUuid, year, month);
+
+    String filename = String.format("expenses_%d-%02d.csv", year, month);
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CONTENT_TYPE, "text/csv; charset=UTF-8")
+        .header(HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"" + filename + "\"")
+        .body(csv);
   }
 
   @Operation(summary = "지출 삭제", description = "지출 내역을 삭제합니다.")

--- a/src/main/java/com/bifos/accountbook/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bifos/accountbook/shared/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.bifos.accountbook.shared.exception;
 import com.bifos.accountbook.shared.exception.BusinessException;
 import com.bifos.accountbook.shared.dto.ApiErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -124,6 +125,16 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(HttpStatus.BAD_REQUEST)
         .body(ApiErrorResponse.of("입력값 검증에 실패했습니다.", errorDetails));
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiErrorResponse> handleConstraintViolationException(
+      ConstraintViolationException ex) {
+    log.warn("Constraint violation: {}", ex.getMessage());
+
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(ApiErrorResponse.of("입력값 검증에 실패했습니다."));
   }
 
   /**

--- a/src/main/java/com/bifos/accountbook/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bifos/accountbook/shared/exception/GlobalExceptionHandler.java
@@ -130,11 +130,27 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(ConstraintViolationException.class)
   public ResponseEntity<ApiErrorResponse> handleConstraintViolationException(
       ConstraintViolationException ex) {
-    log.warn("Constraint violation: {}", ex.getMessage());
+    List<ApiErrorResponse.ErrorDetails> errorDetails = ex.getConstraintViolations()
+        .stream()
+        .map(violation -> {
+          String propertyPath = violation.getPropertyPath().toString();
+          String field = propertyPath.contains(".")
+              ? propertyPath.substring(propertyPath.lastIndexOf('.') + 1)
+              : propertyPath;
+          return ApiErrorResponse.ErrorDetails.builder()
+              .code("CONSTRAINT_VIOLATION")
+              .field(field)
+              .rejectedValue(violation.getInvalidValue())
+              .build();
+        })
+        .collect(Collectors.toList());
+
+    log.warn("Constraint violation: {} errors, details: {}",
+        errorDetails.size(), errorDetails);
 
     return ResponseEntity
         .status(HttpStatus.BAD_REQUEST)
-        .body(ApiErrorResponse.of("입력값 검증에 실패했습니다."));
+        .body(ApiErrorResponse.of("입력값 검증에 실패했습니다.", errorDetails));
   }
 
   /**

--- a/src/test/java/com/bifos/accountbook/expense/presentation/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/bifos/accountbook/expense/presentation/controller/ExpenseControllerTest.java
@@ -1,0 +1,165 @@
+package com.bifos.accountbook.expense.presentation.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bifos.accountbook.category.domain.entity.Category;
+import com.bifos.accountbook.family.domain.entity.Family;
+import com.bifos.accountbook.shared.AbstractControllerTest;
+import com.bifos.accountbook.user.domain.entity.User;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+@DisplayName("지출 CSV 내보내기 API 통합 테스트")
+class ExpenseControllerTest extends AbstractControllerTest {
+
+  private User testUser;
+  private Family testFamily;
+  private Category testCategory;
+
+  @BeforeEach
+  void setUp() {
+    doTransactionWithoutResult(() -> {
+      testUser = fixtures.getDefaultUser();
+      testFamily = fixtures.families.family()
+          .owner(testUser)
+          .budget(new BigDecimal("1000000.00"))
+          .build();
+      testCategory = fixtures.categories.category(testFamily)
+          .name("식비")
+          .build();
+    });
+  }
+
+  @Test
+  @DisplayName("해당 월 지출내역을 CSV로 다운로드할 수 있다")
+  void exportExpensesCsv_Success() throws Exception {
+    doTransactionWithoutResult(() -> {
+      fixtures.expenses.expense(testFamily, testCategory)
+          .amount(new BigDecimal("15000"))
+          .description("점심식사")
+          .date(LocalDateTime.of(2026, 5, 10, 12, 0))
+          .build();
+      fixtures.expenses.expense(testFamily, testCategory)
+          .amount(new BigDecimal("25000"))
+          .description("저녁식사")
+          .date(LocalDateTime.of(2026, 5, 20, 18, 0))
+          .build();
+    });
+
+    MvcResult result = mockMvc.perform(get(
+            "/api/v1/families/{familyUuid}/expenses/export",
+            testFamily.getUuid().getValue())
+            .param("year", "2026")
+            .param("month", "5")
+            .header("X-User-UUID", testUser.getUuid().getValue()))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Content-Type", containsString("text/csv")))
+        .andReturn();
+
+    byte[] body = result.getResponse().getContentAsByteArray();
+    String content = new String(body, StandardCharsets.UTF_8);
+
+    assertThat(content.charAt(0)).isEqualTo('﻿');
+    assertThat(content).contains("날짜,카테고리,금액,설명");
+
+    String[] lines = content.split("\r\n");
+    assertThat(lines).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("해당 월에 지출이 없으면 헤더만 있는 CSV를 반환한다")
+  void exportExpensesCsv_EmptyData() throws Exception {
+    MvcResult result = mockMvc.perform(get(
+            "/api/v1/families/{familyUuid}/expenses/export",
+            testFamily.getUuid().getValue())
+            .param("year", "2026")
+            .param("month", "1")
+            .header("X-User-UUID", testUser.getUuid().getValue()))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Content-Type", containsString("text/csv")))
+        .andReturn();
+
+    byte[] body = result.getResponse().getContentAsByteArray();
+    String content = new String(body, StandardCharsets.UTF_8);
+
+    assertThat(content.charAt(0)).isEqualTo('﻿');
+    assertThat(content).contains("날짜,카테고리,금액,설명");
+
+    String[] lines = content.split("\r\n");
+    assertThat(lines).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("description에 콤마가 있으면 큰따옴표로 감싸진다")
+  void exportExpensesCsv_DescriptionWithComma() throws Exception {
+    doTransactionWithoutResult(() -> {
+      fixtures.expenses.expense(testFamily, testCategory)
+          .amount(new BigDecimal("10000"))
+          .description("식비, 음식")
+          .date(LocalDateTime.of(2026, 5, 15, 12, 0))
+          .build();
+    });
+
+    MvcResult result = mockMvc.perform(get(
+            "/api/v1/families/{familyUuid}/expenses/export",
+            testFamily.getUuid().getValue())
+            .param("year", "2026")
+            .param("month", "5")
+            .header("X-User-UUID", testUser.getUuid().getValue()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    byte[] body = result.getResponse().getContentAsByteArray();
+    String content = new String(body, StandardCharsets.UTF_8);
+    assertThat(content).contains("\"식비, 음식\"");
+  }
+
+  @Test
+  @DisplayName("description에 큰따옴표가 있으면 RFC 4180에 따라 이스케이프된다")
+  void exportExpensesCsv_DescriptionWithDoubleQuote() throws Exception {
+    doTransactionWithoutResult(() -> {
+      fixtures.expenses.expense(testFamily, testCategory)
+          .amount(new BigDecimal("10000"))
+          .description("\"특별\" 식사")
+          .date(LocalDateTime.of(2026, 5, 15, 12, 0))
+          .build();
+    });
+
+    MvcResult result = mockMvc.perform(get(
+            "/api/v1/families/{familyUuid}/expenses/export",
+            testFamily.getUuid().getValue())
+            .param("year", "2026")
+            .param("month", "5")
+            .header("X-User-UUID", testUser.getUuid().getValue()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    byte[] body = result.getResponse().getContentAsByteArray();
+    String content = new String(body, StandardCharsets.UTF_8);
+    assertThat(content).contains("\"\"\"특별\"\" 식사\"");
+  }
+
+  @Test
+  @DisplayName("가족 구성원이 아닌 사용자는 403을 반환한다")
+  void exportExpensesCsv_NotFamilyMember_Forbidden() throws Exception {
+    User otherUser = doTransaction(() -> fixtures.users.getOtherUser());
+    fixtures.users.setSecurityContext(otherUser);
+
+    mockMvc.perform(get(
+            "/api/v1/families/{familyUuid}/expenses/export",
+            testFamily.getUuid().getValue())
+            .param("year", "2026")
+            .param("month", "5")
+            .header("X-User-UUID", otherUser.getUuid().getValue()))
+        .andExpect(status().isForbidden());
+  }
+}

--- a/tasks/plan005-expense-csv-export/index.json
+++ b/tasks/plan005-expense-csv-export/index.json
@@ -3,21 +3,21 @@
   "slug": "expense-csv-export",
   "title": "월별 지출내역 CSV 내보내기 endpoint 추가",
   "issue": "#59",
-  "status": "pending",
+  "status": "completed",
   "phases": [
     {
       "id": "phase-01",
       "title": "CSV 생성 서비스 + 다운로드 endpoint + 테스트",
       "file": "phase-01.md",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": "phase-02",
       "title": "빌드 검증 + 커밋",
       "file": "phase-02.md",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- 월별 지출내역을 CSV 파일로 다운로드하는 `GET /api/v1/families/{familyUuid}/expenses/export?year=&month=` endpoint 추가
- RFC 4180 CSV 표준 준수 (CRLF 행 구분자, 큰따옴표 이스케이프)
- BOM 포함으로 Excel 한글 깨짐 방지
- year/month 파라미터 Bean Validation 적용 (`@Min`/`@Max`)

## Changes

- `ExpenseService.exportMonthlyExpenseCsv()` — CSV 생성 로직 (ACTIVE 상태 지출만 조회, 날짜 내림차순)
- `ExpenseController` — `/export` GET endpoint, `@Validated` 적용
- `GlobalExceptionHandler` — `ConstraintViolationException` 핸들러 추가 (400 반환)
- `docs/prd.md` — F3 섹션에 CSV 내보내기 기능 기록

## Test plan

- [x] 해당 월 지출내역 CSV 다운로드 성공 (데이터 2건)
- [x] 빈 월 — 헤더만 있는 CSV 반환
- [x] description에 콤마 포함 시 큰따옴표 감싸기
- [x] description에 큰따옴표 포함 시 RFC 4180 이스케이프 (`""`)
- [x] 가족 구성원 아닌 사용자 403
- [x] Checkstyle 통과
- [x] 전체 테스트 통과

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
